### PR TITLE
Copy tracing file in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=build /build/next.config.js ./
 COPY --from=build /build/package*.json ./
 COPY --from=build /build/.next ./.next
 COPY --from=build /build/public ./public
+COPY --from=build /build/tracing.js ./
 RUN VERSION_NEXT=`node -p -e "require('./package.json').dependencies.next"`&& npm install --no-package-lock --no-save next@"$VERSION_NEXT"
 
 # Runtime envs -- will default to build args if no env values are specified at docker run


### PR DESCRIPTION
### Description

List of proposed changes:

This should fix the issue with the dast test; error message states "cannot locate 'tracing.js'".
Was able to reproduce locally by runing docker; this fixed that.

### What to test for/How to test

Can build/run docker

### Additional Notes
