### PR TITLE
Updated node version to 18.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17.8-alpine3.15 AS base
+FROM node:18.9-alpine3.15 AS base
 WORKDIR /base
 COPY package*.json ./
 RUN npm ci
@@ -19,7 +19,7 @@ WORKDIR /build
 COPY --from=base /base ./
 RUN npm run build
 
-FROM node:17.8-alpine3.15 AS production
+FROM node:18.9-alpine3.15 AS production
 ENV NODE_ENV=production
 WORKDIR /app
 COPY --from=build /build/next.config.js ./


### PR DESCRIPTION
### Description
Node V17 has been canned and V18.9 is the latest stable

### What to test for/How to test
Ensure application deploys with 18.9