### PR TITLE
Use a seperate env for url path prefix

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -7,7 +7,7 @@ environments:
 
 releases:
 # Single Tier Website
-  - name: sch-{{ requiredEnv "BRANCH" | lower }}
+  - name: {{ requiredEnv "PATH_PREFIX" }}-{{ requiredEnv "BRANCH" | lower }}
     chart: ../helm/charts/{{ requiredEnv "PROJECT" }}
     values:
       - overrides/{{ requiredEnv "PROJECT" }}/{{ requiredEnv "PROJECT" }}.yaml.gotmpl

--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -7,7 +7,7 @@ environments:
 
 releases:
 # Single Tier Website
-  - name: {{ requiredEnv "PROJECT" }}-{{ requiredEnv "BRANCH" | lower }}
+  - name: sch-{{ requiredEnv "BRANCH" | lower }}
     chart: ../helm/charts/{{ requiredEnv "PROJECT" }}
     values:
       - overrides/{{ requiredEnv "PROJECT" }}/{{ requiredEnv "PROJECT" }}.yaml.gotmpl

--- a/helmfile/overrides/secure-client-hub/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/secure-client-hub.yaml.gotmpl
@@ -50,10 +50,10 @@ ingress:
       kubernetes.io/ingress.class: azure/application-gateway
     tls:
       - hosts:
-          - {{ requiredEnv "PROJECT" }}-{{ requiredEnv "BRANCH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}
+          - sch-{{ requiredEnv "BRANCH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}
         secretName: ingress-tls-{{ requiredEnv "BRANCH" | lower }}
     hosts:
-    - host: {{ requiredEnv "PROJECT" }}-{{ requiredEnv "BRANCH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}
+    - host: sch-{{ requiredEnv "BRANCH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/helmfile/overrides/secure-client-hub/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/secure-client-hub.yaml.gotmpl
@@ -50,10 +50,10 @@ ingress:
       kubernetes.io/ingress.class: azure/application-gateway
     tls:
       - hosts:
-          - sch-{{ requiredEnv "BRANCH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}
+          - {{ requiredEnv "PATH_PREFIX" }}-{{ requiredEnv "BRANCH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}
         secretName: ingress-tls-{{ requiredEnv "BRANCH" | lower }}
     hosts:
-    - host: sch-{{ requiredEnv "BRANCH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}
+    - host: {{ requiredEnv "PATH_PREFIX" }}-{{ requiredEnv "BRANCH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}
       paths:
         - path: /
           pathType: ImplementationSpecific


### PR DESCRIPTION
### Description

List of proposed changes:

- Change the URL path for ingress; 
  Rather than re-using the project name, which is needed to match the namespace, I've added a new env variable; set at the project level to `secure-client-hub` and overridden on the dynamic to `sch` so that it's shorter and less truncation of the branch name will occur.

### What to test for/How to test

If you create a new branch from this one (pushed to github), it should deploy to https://sch-d-_branch-name_.bdm-dev-rhp.dts-stn.com
### Additional Notes
