### PR TITLE
added link for pages

### DIFF
--- a/components/PageLink.js
+++ b/components/PageLink.js
@@ -1,0 +1,72 @@
+import PropTypes from 'prop-types'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { Button } from '@dts-stn/service-canada-design-system'
+
+export default function PageLink(props) {
+  const router = useRouter()
+  return (
+    <>
+      <div className="pt-2 md:pt-4 my-8 border-t border-gray-light ">
+        <h2 className="font-display font-bold text-[32px] md:text-[36px]">
+          {props.lookingForText}
+        </h2>
+        <div className="font-body mb-10  text-xl">
+          <span className=" text-gray-darker" id={`link-for-${props.linkText}`}>
+            {props.accessText}{' '}
+          </span>
+          <Link href={props.href}>
+            <a className="text-blue-default hover:text-blue-hover visited:text-purple-medium underline">
+              {props.linkText}
+            </a>
+          </Link>
+        </div>
+
+        <Button
+          id={props.buttonId}
+          onClick={() => router.push('/home')}
+          styling={props.styling}
+          text={props.buttonText}
+        />
+      </div>
+    </>
+  )
+}
+
+PageLink.propTypes = {
+  // Props for the text and link
+  lookingForText: PropTypes.string,
+  linkText: PropTypes.string,
+  accessText: PropTypes.string,
+  href: PropTypes.string,
+  // Props for the Button
+  id: PropTypes.string,
+  buttonId: PropTypes.string,
+  styling: PropTypes.string,
+  buttonText: PropTypes.string,
+}
+
+//   use on Profile page
+// import PageLink from '../components/PageLink'
+//   <PageLink
+//   lookingForText={t.pageLinkSecurity}
+//   accessText={t.accessYourSecurityText}
+//   linkText={t.securityLinkText}
+//   href="/security"
+//   id="link-id"
+//   buttonId="button-back"
+//   styling="secondary"
+//   buttonText={t.backToDashboard}
+// ></PageLink>
+
+//use on security page
+//   <PageLink
+//   lookingForText={t.pageLinkProfile}
+//   accessText={t.accessYourProfileText}
+//   linkText={t.profileLinkText}
+//   href="/profile"
+//   id="link-id"
+//   buttonId="button-back"
+//   styling="secondary"
+//   buttonText={t.backToDashboard}
+// ></PageLink>

--- a/locales/en.js
+++ b/locales/en.js
@@ -21,7 +21,7 @@ export default {
   accessYourSecurityText: 'Access your ',
 
   pageLinkProfile: 'Looking for profile settings?',
-  profileLinkText: 'profile',
+  profileLinkText: 'profile.',
 
   accessYourProfileText: 'Access your ',
   backToDashboard: 'Back to my Dashboard',

--- a/locales/en.js
+++ b/locales/en.js
@@ -16,6 +16,16 @@ export default {
     title: 'My dashboard',
   },
 
+  pageLinkSecurity: 'Looking for security settings?',
+  securityLinkText: 'security settings.',
+  accessYourSecurityText: 'Access your ',
+
+  pageLinkProfile: 'Looking for profile settings?',
+  profileLinkText: 'profile',
+
+  accessYourProfileText: 'Access your ',
+  backToDashboard: 'Back to my Dashboard',
+
   // ViewMoreLessButton
   viewMoreLessButtonCaption: `Applications, payments and claims, taxes, reports and documents, personal information`,
 

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -20,7 +20,7 @@ export default {
   accessYourSecurityText: 'Accéder à vos ',
 
   pageLinkProfile: 'Vous recherchez les paramètres de votre profil?',
-  profileLinkText: 'profile',
+  profileLinkText: 'profile.',
   accessYourProfileText: 'Accéder à votre ',
   backToDashboard: 'Retour à mon tableau de bord',
 

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -15,6 +15,14 @@ export default {
   pageHeading: {
     title: 'Mon tableau de bord',
   },
+  pageLinkSecurity: 'Vous recherchez les paramètres de sécurité?',
+  securityLinkText: 'paramètres de sécurité.',
+  accessYourSecurityText: 'Accéder à vos ',
+
+  pageLinkProfile: 'Vous recherchez les paramètres de votre profil?',
+  profileLinkText: 'profile',
+  accessYourProfileText: 'Accéder à votre ',
+  backToDashboard: 'Retour à mon tableau de bord',
 
   // ViewMoreLessButton
   viewMoreLessButtonCaption: `Demandes, paiements et réclamations, impôts, rapports et documents, informations personnelles`,


### PR DESCRIPTION
## [ADO-81794](https://dev.azure.com/VP-BD/DECD/_workitems/edit/81794)

### Description

List of proposed changes:
Added text and link for navigating security and profile page
Added button to return to dashboard '/home' page
- the components are ready to be added in the commented out text that can then be removed once added to each page once completed.

### What to test for/How to test
Test will come later

### Additional Notes
Please check the router bit. 
Text will eventually come from AEM.
