### PR TITLE
80959_TestCases

### DIFF
--- a/cypress/e2e/PageObjects/dashboardPO.cy.js
+++ b/cypress/e2e/PageObjects/dashboardPO.cy.js
@@ -56,6 +56,18 @@ function MostRequestedSectionLinks() {
 
 }
 
+function Menu() {
+
+  return cy.get("#dropdownNavbarLink")
+
+}
+
+function SecuritySettingsMenu() {
+
+  return cy.get("[href = '/security']")
+
+}
+
 
 module.exports = {dashboardHeader,
                    FrenchButton,
@@ -66,7 +78,10 @@ module.exports = {dashboardHeader,
                    Cards,
                    MostRequestedSection,
                    MostRequestedSectionLinks,
-                   MostRequestedSectionHeading
+                   MostRequestedSectionHeading,
+                   Menu,
+                   SecuritySettingsMenu
+
 
 
 }

--- a/cypress/e2e/PageObjects/dashboardPO.cy.js
+++ b/cypress/e2e/PageObjects/dashboardPO.cy.js
@@ -64,7 +64,7 @@ function Menu() {
 
 function SecuritySettingsMenu() {
 
-  return cy.get("[href = '/security']")
+  return cy.get("#dropdownNavbar > li:nth-child(2) > a")
 
 }
 

--- a/cypress/e2e/PageObjects/securitySettingsPO.cy.js
+++ b/cypress/e2e/PageObjects/securitySettingsPO.cy.js
@@ -1,0 +1,30 @@
+/// <reference types="cypress" />
+
+
+function securitySettingsHeader(){
+
+    return cy.get('#my-dashboard-heading')
+      }
+
+function breadcrumbs() {
+
+    return cy.get("[class='ds-container'] >nav>ul")
+}
+
+function breadcrumbsLink1() {
+
+    return cy.get("[class='ds-container'] >nav>ul>li:nth-child(1)>a")
+}
+
+function breadcrumbsLink2() {
+
+    return cy.get("[class='ds-container'] >nav>ul>li:nth-child(2)>a")
+}
+
+      module.exports = {securitySettingsHeader,
+                        breadcrumbs,
+                        breadcrumbsLink1,
+                        breadcrumbsLink2
+
+
+      }

--- a/cypress/e2e/SecuritySettings.cy.js
+++ b/cypress/e2e/SecuritySettings.cy.js
@@ -49,5 +49,18 @@ describe('Validate Security Settings page',() =>{
 
            
          })
+
+         it('validate that user is navigated to /fr/security page from /fr/dashboard', () =>{
+            
+            cy.visit('/home')
+            dashboardPo.FrenchButton().click()
+            dashboardPo.Menu().click()
+            dashboardPo.SecuritySettingsMenu().click()
+            cy.url().should("contains", "/fr/security")
+            securityPo.securitySettingsHeader().should('be.visible')
+                                     .and('have.text','Paramètres de sécurité');
+            
+           
+         })
             
     })

--- a/cypress/e2e/SecuritySettings.cy.js
+++ b/cypress/e2e/SecuritySettings.cy.js
@@ -44,8 +44,6 @@ describe('Validate Security Settings page',() =>{
          it('validate the breadcrumbs are present on Security settings page', () =>{
             
             securityPo.breadcrumbs().should('be.visible')
-            securityPo.breadcrumbsLink1().should('have.attr','href','https://www.canada.ca/home.html')
-            securityPo.breadcrumbsLink2().should('have.attr','href','https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html')
 
            
          })

--- a/cypress/e2e/SecuritySettings.cy.js
+++ b/cypress/e2e/SecuritySettings.cy.js
@@ -1,0 +1,53 @@
+/// <reference types="cypress" />
+const dashboardPo = require("../e2e/PageObjects/dashboardPO.cy")
+const securityPo = require("../e2e/PageObjects/securitySettingsPO.cy")
+
+
+beforeEach(() => {
+cy.visit('/security') })
+
+describe('Validate Security Settings page',() =>{
+
+
+       it('Validate Security Settings Page header in English', () =>{
+
+           securityPo.securitySettingsHeader().should('be.visible')
+                                     .and('have.text','Security Settings');
+        
+        })
+
+        it('Validate French button click goes to fr/Security page', () =>{
+
+            dashboardPo.FrenchButton().click()
+            cy.url().should("contains", "/fr/security");
+         
+         })
+
+         it('Validate Security Settings Page header in French', () =>{
+
+            dashboardPo.FrenchButton().click()
+            securityPo.securitySettingsHeader().should('be.visible')
+                                     .and('have.text','Paramètres de sécurité');
+         
+         })
+
+         it('Validate that user can select "Security settings" from Menu dropdown options', () =>{
+            cy.visit('/home')
+            dashboardPo.Menu().click()
+            dashboardPo.SecuritySettingsMenu().click()
+            cy.url().should("contains", "/security");
+            securityPo.securitySettingsHeader().should('be.visible')
+                                     .and('have.text','Security Settings');
+
+         })
+
+         it('validate the breadcrumbs are present on Security settings page', () =>{
+            
+            securityPo.breadcrumbs().should('be.visible')
+            securityPo.breadcrumbsLink1().should('have.attr','href','https://www.canada.ca/home.html')
+            securityPo.breadcrumbsLink2().should('have.attr','href','https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html')
+
+           
+         })
+            
+    })


### PR DESCRIPTION
## [ADO-81785](https://dev.azure.com/VP-BD/DECD/_workitems/edit/81785)

### Description

List of proposed changes:
- Test case added to validate Security settings page heading in English
- Test case added to validate Security settings page heading in French
- Test case to validate French button click goes to /fr/security
- Test case added to validate that user can select 'Security Settings' option from Menu dropdown
- Test case added to validate the breadcrumbs are present on security settings page

### What to test for/How to test
Validate Security settings page heading and breadcrumbs using cypress tests

### Additional Notes
