### PR TITLE
73203_E2E_TCs

### DIFF
--- a/cypress/e2e/PageObjects/ProfilePO.cy.js
+++ b/cypress/e2e/PageObjects/ProfilePO.cy.js
@@ -1,0 +1,1 @@
+/// <reference types="cypress" />

--- a/cypress/e2e/PageObjects/dashboardPO.cy.js
+++ b/cypress/e2e/PageObjects/dashboardPO.cy.js
@@ -89,6 +89,4 @@ module.exports = {dashboardHeader,
                    ProfileMenu,
                    SecuritySettingsMenu
 
-
-
 }

--- a/cypress/e2e/PageObjects/dashboardPO.cy.js
+++ b/cypress/e2e/PageObjects/dashboardPO.cy.js
@@ -68,6 +68,14 @@ function SecuritySettingsMenu() {
 
 }
 
+function ProfileMenu() {
+
+  return cy.get("#dropdownNavbar > li:nth-child(3) > a")
+
+}
+
+
+
 
 module.exports = {dashboardHeader,
                    FrenchButton,
@@ -80,7 +88,8 @@ module.exports = {dashboardHeader,
                    MostRequestedSectionLinks,
                    MostRequestedSectionHeading,
                    Menu,
-                   SecuritySettingsMenu
+                   SecuritySettingsMenu,
+                   ProfileMenu
 
 
 

--- a/cypress/e2e/PageObjects/dashboardPO.cy.js
+++ b/cypress/e2e/PageObjects/dashboardPO.cy.js
@@ -86,7 +86,7 @@ module.exports = {dashboardHeader,
                    MostRequestedSectionHeading,
                    Menu,
                    SecuritySettingsMenu,
-                   ProfileMenu
+                   ProfileMenu,
                    SecuritySettingsMenu
 
 

--- a/cypress/e2e/PageObjects/securitySettingsPO.cy.js
+++ b/cypress/e2e/PageObjects/securitySettingsPO.cy.js
@@ -1,14 +1,14 @@
 /// <reference types="cypress" />
 
 
-function securitySettingsHeader(){
+function pageHeader(){
 
     return cy.get('#my-dashboard-heading')
       }
 
 function breadcrumbs() {
 
-    return cy.get("[class='ds-container'] >nav>ul")
+    return cy.get("[class='ds-container'] >nav>ul>li>a")
 }
 
 function breadcrumbsLink1() {
@@ -21,7 +21,7 @@ function breadcrumbsLink2() {
     return cy.get("[class='ds-container'] >nav>ul>li:nth-child(2)>a")
 }
 
-      module.exports = {securitySettingsHeader,
+      module.exports = {pageHeader,
                         breadcrumbs,
                         breadcrumbsLink1,
                         breadcrumbsLink2

--- a/cypress/e2e/Profile.cy.js
+++ b/cypress/e2e/Profile.cy.js
@@ -11,17 +11,18 @@ beforeEach(() => {
     describe('Validate Profile page',() =>{
     
     
-           it('Validate Security Settings Page header in English', () =>{
+           it('Validate Profile Page header in English', () =>{
     
                securityPo.pageHeader().should('be.visible')
                                          .and('have.text','Profile');
             
             })
 
-            it('Validate Security Settings Page header in English', () =>{
-    
+            it('Validate Profile Page header in French', () =>{
+                
+                dashboardPo.FrenchButton().click()
                 securityPo.pageHeader().should('be.visible')
-                                          .and('have.text','Profile');
+                                          .and('have.text','Profil');
              
              })
 
@@ -56,7 +57,7 @@ beforeEach(() => {
              })
     
              
-             it('validate the "My dashboard" click goes to dashboard page', () =>{
+             it('validate the "My dashboard" click from profile page goes to dashboard page', () =>{
                 
                 securityPo.breadcrumbs().click()
                 cy.url().should("contains", "/home");

--- a/cypress/e2e/Profile.cy.js
+++ b/cypress/e2e/Profile.cy.js
@@ -1,0 +1,82 @@
+/// <reference types="cypress" />
+/// <reference types="cypress" />
+
+const dashboardPo = require("../e2e/PageObjects/dashboardPO.cy")
+const securityPo = require("../e2e/PageObjects/securitySettingsPO.cy")
+const profilePo = require("../e2e/PageObjects/ProfilePO.cy")
+
+beforeEach(() => {
+    cy.visit('/profile') })
+    
+    describe('Validate Profile page',() =>{
+    
+    
+           it('Validate Security Settings Page header in English', () =>{
+    
+               securityPo.pageHeader().should('be.visible')
+                                         .and('have.text','Profile');
+            
+            })
+
+            it('Validate Security Settings Page header in English', () =>{
+    
+                securityPo.pageHeader().should('be.visible')
+                                          .and('have.text','Profile');
+             
+             })
+
+             it('validate the breadcrumbs are present on Profile page', () =>{
+            
+                securityPo.breadcrumbs().should('be.visible').and('have.text',"My dashboard")
+                dashboardPo.FrenchButton().click()
+                securityPo.breadcrumbs().should('be.visible').and('have.text',"Mon tableau de bord")
+       
+             })
+
+             it('validate the "My dashboard" click on Profile page goes to dashboard page', () =>{
+            
+                securityPo.breadcrumbs().click()
+                cy.url().should("contains", "/home");
+                dashboardPo.dashboardHeader().should('be.visible')
+                .and('have.text','My dashboard');
+       
+             })
+
+             it('validate that user is navigated to /fr/profile page from /fr/dashboard', () =>{
+            
+                cy.visit('/home')
+                dashboardPo.FrenchButton().click()
+                dashboardPo.Menu().click()
+                dashboardPo.ProfileMenu().click()
+                cy.url().should("contains", "/fr/profile")
+                securityPo.pageHeader().should('be.visible')
+                                         .and('have.text','Profil');
+                
+               
+             })
+    
+             
+             it('validate the "My dashboard" click goes to dashboard page', () =>{
+                
+                securityPo.breadcrumbs().click()
+                cy.url().should("contains", "/home");
+                dashboardPo.dashboardHeader().should('be.visible')
+                .and('have.text','My dashboard');
+       
+             })
+                
+             it('validate the "Mon tableau de bord" click goes from Profile to "/fr/home"page', () =>{
+                
+                dashboardPo.FrenchButton().click()
+                securityPo.breadcrumbs().click()
+                cy.url().should("contains", "/fr/home");
+                dashboardPo.dashboardHeader().should('be.visible')
+                .and('have.text','Mon tableau de bord');
+       
+             })
+    
+
+
+
+
+        })

--- a/cypress/e2e/SecuritySettings.cy.js
+++ b/cypress/e2e/SecuritySettings.cy.js
@@ -11,7 +11,7 @@ describe('Validate Security Settings page',() =>{
 
        it('Validate Security Settings Page header in English', () =>{
 
-           securityPo.securitySettingsHeader().should('be.visible')
+           securityPo.pageHeader().should('be.visible')
                                      .and('have.text','Security Settings');
         
         })
@@ -26,7 +26,7 @@ describe('Validate Security Settings page',() =>{
          it('Validate Security Settings Page header in French', () =>{
 
             dashboardPo.FrenchButton().click()
-            securityPo.securitySettingsHeader().should('be.visible')
+            securityPo.pageHeader().should('be.visible')
                                      .and('have.text','Paramètres de sécurité');
          
          })
@@ -36,31 +36,49 @@ describe('Validate Security Settings page',() =>{
             dashboardPo.Menu().click()
             dashboardPo.SecuritySettingsMenu().click()
             cy.url().should("contains", "/security");
-            securityPo.securitySettingsHeader().should('be.visible')
+            securityPo.pageHeader().should('be.visible')
                                      .and('have.text','Security Settings');
 
          })
-
-         it('validate the breadcrumbs are present on Security settings page', () =>{
-            
-            securityPo.breadcrumbs().should('be.visible')
-            securityPo.breadcrumbsLink1().should('have.attr','href','https://www.canada.ca/home.html')
-            securityPo.breadcrumbsLink2().should('have.attr','href','https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html')
-
-           
-         })
-
-         it('validate that user is navigated to /fr/security page from /fr/dashboard', () =>{
+it('validate that user is navigated to /fr/security page from /fr/dashboard', () =>{
             
             cy.visit('/home')
             dashboardPo.FrenchButton().click()
             dashboardPo.Menu().click()
             dashboardPo.SecuritySettingsMenu().click()
             cy.url().should("contains", "/fr/security")
-            securityPo.securitySettingsHeader().should('be.visible')
+            securityPo.pageHeader().should('be.visible')
                                      .and('have.text','Paramètres de sécurité');
             
            
          })
+
+         
+         it('validate the "My dashboard" click goes to dashboard page', () =>{
             
+            securityPo.breadcrumbs().click()
+            cy.url().should("contains", "/home");
+            dashboardPo.dashboardHeader().should('be.visible')
+            .and('have.text','My dashboard');
+   
+         })
+            
+         it('validate the "Mon tableau de bord" click goes from Security to "/fr/home"page', () =>{
+            
+            dashboardPo.FrenchButton().click()
+            securityPo.breadcrumbs().click()
+            cy.url().should("contains", "/fr/home");
+            dashboardPo.dashboardHeader().should('be.visible')
+            .and('have.text','Mon tableau de bord');
+   
+         })
+         it('validate the breadcrumbs are present on Security settings page', () =>{
+            
+            securityPo.breadcrumbs().should('be.visible').and('have.text',"My dashboard")
+            dashboardPo.FrenchButton().click()
+            securityPo.breadcrumbs().should('be.visible').and('have.text',"Mon tableau de bord")
+   
+         })
+
+         
     })

--- a/cypress/e2e/dashboard.cy.js
+++ b/cypress/e2e/dashboard.cy.js
@@ -1,5 +1,6 @@
 /// <reference types="cypress" />
 const dashboardPo = require("../e2e/PageObjects/dashboardPO.cy")
+const securityPo = require("../e2e/PageObjects/securitySettingsPO.cy")
 
 
 beforeEach(() => {
@@ -77,6 +78,12 @@ describe('Validate dashboard page',() =>{
           })
 
         })
+
+        it('validate the "My dashboard" page doesnt have breadcrumbs', () =>{
+            
+          securityPo.breadcrumbs().should('not.exist')
+ 
+       })
 
 })
 


### PR DESCRIPTION
## [ADO-81797](https://dev.azure.com/VP-BD/DECD/_workitems/edit/81797)

### Description

List of proposed changes:
- Validate Profile Page header in English
- Validate Profile Page header in French
- validate the breadcrumbs are present on Profile page
- validate the "My dashboard" click on Profile page goes to dashboard page
- validate that user is navigated to /fr/profile page from /fr/dashboard
- validate the "My dashboard" click from profile page goes to dashboard page
- validate the "Mon tableau de bord" click goes from Profile to "/fr/home"page

### What to test for/How to test
Validate Security settings page and Profile page has "My dashboard" breadcrumbs using cypress tests



### Additional Notes
