### PR TITLE
Security query and mapper.

### DIFF
--- a/graphql/mappers/security.js
+++ b/graphql/mappers/security.js
@@ -1,0 +1,104 @@
+import clientQuery from '../client'
+
+export async function getSecurityContent() {
+  const query = require('../queries/security.graphql')
+  const response = await clientQuery(query)
+
+  const enLookingForFragment = findFragmentByScId(
+    response,
+    'looking-for-profile-settings',
+    'en'
+  )
+  const enContentFragment = findFragmentByScId(
+    response,
+    'security-settings-main-content',
+    'en'
+  )
+  const frLookingForFragment = findFragmentByScId(
+    response,
+    'looking-for-profile-settings',
+    'fr'
+  )
+  const frContentFragment = findFragmentByScId(
+    response,
+    'security-settings-main-content',
+    'fr'
+  )
+  const mappedSecurity = {
+    en: {
+      pageName: response.data.schPagev1ByPath.item.scPageNameEn,
+      heading: response.data.schPagev1ByPath.item.scTitleEn,
+      lookingFor: {
+        title: enLookingForFragment.json[0].content[0].value,
+        subText: enLookingForFragment.json[1].content.map((element) => {
+          if (element.value) {
+            return element.value
+          }
+          return null
+        }),
+        link: '/profile',
+      },
+      content: {
+        subHeading: enContentFragment.json[0].content[0].value,
+        securityQuestions: {
+          linkTitle: {
+            text: enContentFragment.json[1].content[0].value,
+            link: enContentFragment.json[1].content[0].data.href,
+          },
+          subTitle: enContentFragment.json[1].content[2].value,
+        },
+        eiAccessCode: {
+          linkTitle: {
+            text: enContentFragment.json[2].content[0].value,
+            link: enContentFragment.json[2].content[0].data.href,
+          },
+          subTitle: enContentFragment.json[2].content[2].value,
+        },
+      },
+    },
+    fr: {
+      pageName: response.data.schPagev1ByPath.item.scPageNameFr,
+      heading: response.data.schPagev1ByPath.item.scTitleFr,
+      lookingFor: {
+        title: frLookingForFragment.json[0].content[0].value,
+        subText: frLookingForFragment.json[1].content.map((element) => {
+          if (element.value) {
+            return element.value
+          }
+          return null
+        }),
+        link: '/fr/profile',
+      },
+      content: {
+        subHeading: frContentFragment.json[0].content[0].value,
+        securityQuestions: {
+          linkTitle: {
+            text: frContentFragment.json[1].content[0].value,
+            link: frContentFragment.json[1].content[0].data.href,
+          },
+          subTitle: frContentFragment.json[1].content[2].value,
+        },
+        eiAccessCode: {
+          linkTitle: {
+            text: frContentFragment.json[2].content[0].value,
+            link: frContentFragment.json[2].content[0].data.href,
+          },
+          subTitle: frContentFragment.json[2].content[2].value,
+        },
+      },
+    },
+  }
+  return mappedSecurity
+}
+
+const findFragmentByScId = (res, id, lang) => {
+  if (lang === 'fr') {
+    return res.data.schPagev1ByPath.item.scFragments.find(
+      (element) => element.scId === id
+    ).scContentFr
+  } else if (lang === 'en') {
+    return res.data.schPagev1ByPath.item.scFragments.find(
+      (element) => element.scId === id
+    ).scContentEn
+  }
+}

--- a/graphql/queries/security.graphql
+++ b/graphql/queries/security.graphql
@@ -1,0 +1,38 @@
+{
+  schPagev1ByPath(
+    _path: "/content/dam/decd-endc/content-fragments/sch/pages/security-settings"
+  ) {
+    item {
+      _path
+      scPageNameEn
+      scPageNameFr
+      scTitleEn
+      scTitleFr
+      scBreadcrumbParentPages {
+        ... on SCHPagev1Model {
+          scTitleEn
+          scId
+        }
+      }
+      scFragments {
+        ... on SCHTaskv1Model {
+          scId
+          scDestinationURLEn
+          scDestinationURLFr
+          scButtonType
+          scTitleEn
+          scTitleFr
+        }
+        ... on SCHContentv1Model {
+          scId
+          scContentFr {
+            json
+          }
+          scContentEn {
+            json
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## [Security Query](https://dev.azure.com/VP-BD/DECD/_workitems/edit/81787)

### Description

- Added security query.
- Added security aem mapper.

### Notes

- Breadcrumb content is not being used from the query for now.
- The logic for the mapper is not the best and there are no checks for errors. Thats why we throw errors from the `security.js` page. Any thoughts on making it better?
