### PR TITLE
Bug 87058 Dashboard new tab exceptions

### DIFF
--- a/components/BenefitTasks.js
+++ b/components/BenefitTasks.js
@@ -2,9 +2,13 @@ import PropTypes from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Link from 'next/link'
 import { icon } from '../lib/loadIcons'
-import { solid } from '@fortawesome/fontawesome-svg-core/import.macro'
 
 export default function BenefitTasks(props) {
+  const newTabTaskExceptions = [
+    'https://www.canada.ca/en/services/benefits/ei/ei-regular-benefit/apply.html#gc-document-nav',
+    'https://www.canada.ca/en/services/benefits/ei/employment-insurance-reporting.html',
+  ]
+
   return (
     <div className="inline-block w-full">
       <h3 className="font-body font-bold text-xl " data-cy={props.dataCy}>
@@ -20,7 +24,13 @@ export default function BenefitTasks(props) {
               <Link href={task.link} passHref>
                 <a
                   onClick={(e) => {
-                    if (task.betaPopUp) {
+                    //check for new tab exceptions
+                    if (newTabTaskExceptions.includes(task.link)) {
+                      e.preventDefault()
+                      window.open(task.link)
+                    }
+                    //check for exit beta popup flag, else keep default anchor behavior
+                    else if (task.betaPopUp) {
                       e.preventDefault()
                       props.openModal(task.link)
                     }

--- a/components/BenefitTasks.js
+++ b/components/BenefitTasks.js
@@ -23,14 +23,17 @@ export default function BenefitTasks(props) {
             <li key={index} className="font-body font-bold" data-cy="task-link">
               <Link href={task.link} passHref>
                 <a
+                  target={
+                    newTabTaskExceptions.includes(task.link)
+                      ? '_blank'
+                      : '_self'
+                  }
                   onClick={(e) => {
-                    //check for new tab exceptions
-                    if (newTabTaskExceptions.includes(task.link)) {
-                      e.preventDefault()
-                      window.open(task.link)
-                    }
-                    //check for exit beta popup flag, else keep default anchor behavior
-                    else if (task.betaPopUp) {
+                    //check for exit beta popup flag and not a new tab link, else keep default anchor behavior
+                    if (
+                      task.betaPopUp &&
+                      !newTabTaskExceptions.includes(task.link)
+                    ) {
                       e.preventDefault()
                       props.openModal(task.link)
                     }


### PR DESCRIPTION
## [ADO-87058](https://dev.azure.com/VP-BD/DECD/_workitems/edit/87058)

### Description
Bug 87058 Dashboard new tab exceptions

List of proposed changes:
- Add new tab exception array to allow for links to open in new tabs (https://www.canada.ca/en/services/benefits/ei/ei-regular-benefit/apply.html#gc-document-nav, https://www.canada.ca/en/services/benefits/ei/employment-insurance-reporting.html)
- Since opening in a new tab we bypass the exit beta pop up logic

### What to test for/How to test
Open the app and check if the links open in new tabs. Others should keep existing logic.
