### PR TITLE
87175 beta banner popup

### DIFF
--- a/components/PhaseBanner.js
+++ b/components/PhaseBanner.js
@@ -50,32 +50,27 @@ export default function PhaseBanner(props) {
             ></FontAwesomeIcon>
           </a>
         </div>
-        <a
-          href={'#'}
-          className="max-h-11 my-auto w-full justify-center px-auto sm:w-auto"
-        >
-          <Button
-            id="bannerButton"
-            styling="primary"
-            text={props.bannerButtonText}
-            className="font-body text-xl whitespace-nowrap"
-            onClick={(e) => {
-              e.preventDefault()
-              openModal(props.bannerButtonLink)
-            }}
-          ></Button>
-        </a>
+        <Button
+          id="bannerButton"
+          styling="primary"
+          text={props.bannerButtonText}
+          className="font-body text-xl whitespace-nowrap max-h-11 my-auto w-full justify-center px-auto sm:w-auto"
+          onClick={(e) => {
+            e.preventDefault()
+            openModal(props.bannerButtonLink)
+          }}
+        ></Button>
       </div>
 
       <Modal
         className="flex justify-center bg-black/75 h-full"
         isOpen={openModalWithLink.isOpen}
         onRequestClose={closeModal}
-        contentLabel={'Lorem Upsum Text'}
+        contentLabel={'Modal'}
       >
         <ExitBeta
           closeModal={closeModal}
-          closeModalAria={'Lorem Upsum Text'}
+          closeModalAria={props.bannerButtonText}
           continueLink={openModalWithLink.activeLink}
         />
       </Modal>

--- a/components/PhaseBanner.js
+++ b/components/PhaseBanner.js
@@ -2,12 +2,28 @@ import propTypes from 'prop-types'
 import { Button } from '@dts-stn/service-canada-design-system'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { icon } from '../lib/loadIcons'
+import Modal from 'react-modal'
+import React from 'react'
+import ExitBeta from './ExitBetaModal'
 
 /**
  * Displays the PhaseBanner on the page
  */
 
 export default function PhaseBanner(props) {
+  const [openModalWithLink, setOpenModalWithLink] = React.useState({
+    isOpen: false,
+    activeLink: '/',
+  })
+
+  function openModal(link) {
+    setOpenModalWithLink({ isOpen: true, activeLink: link })
+  }
+
+  function closeModal() {
+    setOpenModalWithLink({ isOpen: false, activeLink: '/' })
+  }
+
   return (
     <div className="bg-brighter-blue-medium">
       <div
@@ -28,7 +44,7 @@ export default function PhaseBanner(props) {
           </a>
         </div>
         <a
-          href={props.bannerButtonLink}
+          href={'#'}
           className="max-h-11 my-auto w-full justify-center px-auto sm:w-auto"
         >
           <Button
@@ -36,9 +52,26 @@ export default function PhaseBanner(props) {
             styling="primary"
             text={props.bannerButtonText}
             className="text-sm"
+            onClick={(e) => {
+              e.preventDefault()
+              openModal(props.bannerButtonLink)
+            }}
           ></Button>
         </a>
       </div>
+
+      <Modal
+        className="flex justify-center bg-black/75 h-full"
+        isOpen={openModalWithLink.isOpen}
+        onRequestClose={closeModal}
+        contentLabel={'Lorem Upsum Text'}
+      >
+        <ExitBeta
+          closeModal={closeModal}
+          closeModalAria={'Lorem Upsum Text'}
+          continueLink={openModalWithLink.activeLink}
+        />
+      </Modal>
     </div>
   )
 }

--- a/cypress/e2e/PageObjects/dashboardPO.cy.js
+++ b/cypress/e2e/PageObjects/dashboardPO.cy.js
@@ -141,7 +141,7 @@ function LearnMoreABtBetaLink() {
 }
 
 function ExitBetaButton() {
-  return cy.get("[data-cy ='topBanner']>a>button")
+  return cy.get("[data-cy ='topBanner']>button")
 }
 
 function FirstTaskLink() {

--- a/cypress/e2e/dashboard.cy.js
+++ b/cypress/e2e/dashboard.cy.js
@@ -112,12 +112,6 @@ describe('Validate dashboard page', () => {
     dashboardPo.ExitBetaButton().should('be.visible')
   })
 
-  it('Validate Beta Version Banner is present on Dashboard', () => {
-    dashboardPo.BetaBanner().should('be.visible')
-    dashboardPo.LearnMoreABtBetaLink().should('be.visible')
-    dashboardPo.ExitBetaButton().should('be.visible')
-  })
-
   it.skip('Validate Exit Beta Version Popup UI', () => {
     dashboardPo.ExpandCard('Employment Insurance')
     dashboardPo.FirstTaskLink().click()

--- a/graphql/mappers/beta-banner-opt-out.js
+++ b/graphql/mappers/beta-banner-opt-out.js
@@ -14,8 +14,7 @@ export async function getBetaBannerContent() {
       bannerLinkHref: resOptOutContent.scFragments[0].scDestinationURLEn,
       bannerButtonText: resOptOutContent.scFragments[1].scLinkTextEn,
       bannerButtonLink:
-        resOptOutContent.scFragments[1].scDestinationURLEn ||
-        'https://en.wikipedia.org',
+        resOptOutContent.scFragments[1].scDestinationURLEn || '/',
       icon: resOptOutContent.scFragments[0].scIconCSS,
     },
     fr: {
@@ -25,8 +24,7 @@ export async function getBetaBannerContent() {
       bannerLinkHref: resOptOutContent.scFragments[0].scDestinationURLFr,
       bannerButtonText: resOptOutContent.scFragments[1].scLinkTextFr,
       bannerButtonLink:
-        resOptOutContent.scFragments[1].scDestinationURLFr ||
-        'https://en.wikipedia.org',
+        resOptOutContent.scFragments[1].scDestinationURLFr || '/',
       icon: resOptOutContent.scFragments[0].scIconCSS,
     },
   }

--- a/graphql/mappers/beta-banner-opt-out.js
+++ b/graphql/mappers/beta-banner-opt-out.js
@@ -13,7 +13,9 @@ export async function getBetaBannerContent() {
       bannerLink: resOptOutContent.scFragments[0].scLinkTextEn,
       bannerLinkHref: resOptOutContent.scFragments[0].scDestinationURLEn,
       bannerButtonText: resOptOutContent.scFragments[1].scLinkTextEn,
-      bannerButtonLink: resOptOutContent.scFragments[1].scDestinationURLFr,
+      bannerButtonLink:
+        resOptOutContent.scFragments[1].scDestinationURLEn ||
+        'https://en.wikipedia.org',
       icon: resOptOutContent.scFragments[0].scIconCSS,
     },
     fr: {
@@ -22,7 +24,9 @@ export async function getBetaBannerContent() {
       bannerLink: resOptOutContent.scFragments[0].scLinkTextFr,
       bannerLinkHref: resOptOutContent.scFragments[0].scDestinationURLFr,
       bannerButtonText: resOptOutContent.scFragments[1].scLinkTextFr,
-      bannerButtonLink: resOptOutContent.scFragments[1].scDestinationURLFr,
+      bannerButtonLink:
+        resOptOutContent.scFragments[1].scDestinationURLFr ||
+        'https://en.wikipedia.org',
       icon: resOptOutContent.scFragments[0].scIconCSS,
     },
   }


### PR DESCRIPTION
## [ADO-87175](https://dev.azure.com/VP-BD/DECD/_workitems/edit/87175)

### Description

List of proposed changes:

- Added popup to banner
- If no link is sent from GraphQL, forward user to wikipedia as a placeholder value. 

### What to test for/How to test

 - Click on button "Exit Beta Version". Modal should open. 
 - Clicking on "Exit Beta Version" in modal should forward user to placeholder next page. 

### Additional Notes

"scDestinationURLEn" and "scDestinationURLFr" generate error when null. GraphQL query should be updated to return URL values.