### PR TITLE
86051 Phase banner transition

### DIFF
--- a/components/PhaseBanner.js
+++ b/components/PhaseBanner.js
@@ -24,7 +24,10 @@ export default function PhaseBanner(props) {
             className="text-deep-blue-dark hover:text-blue-hover"
           >
             <span className="mr-2 underline">{props.bannerLink}</span>
-            <FontAwesomeIcon icon={icon[props.icon]}></FontAwesomeIcon>
+            <FontAwesomeIcon
+              width="14"
+              icon={icon[props.icon]}
+            ></FontAwesomeIcon>
           </a>
         </div>
         <a


### PR DESCRIPTION
## [ADO-86051](https://dev.azure.com/VP-BD/DECD/_workitems/edit/86051)

### Description

List of proposed changes:

- Default size set on icon to prevent icon flash

### What to test for/How to test
- This should fix the icon flash in the live build (subject to testing)

### Additional Notes
- Noted issue with NextJS, this is the workaround
