### PR TITLE
Adding all AEM popup content.

### DIFF
--- a/__tests__/components/ExitBetaModal.test.js
+++ b/__tests__/components/ExitBetaModal.test.js
@@ -12,14 +12,24 @@ describe('Exit Beta Modal', () => {
         closeModal={() => {}}
         closeModalAria={'close'}
         continueLink="/"
+        popupId={'Test Id'}
+        popupTitle={'Test Title'}
+        popupDescription={'Test Description'}
+        popupPrimaryBtn={{ id: 'Test Primary Id', text: 'Test Primary Text' }}
+        popupSecondaryBtn={{
+          id: 'Test Secondary Id',
+          text: 'Test Secondary Text',
+        }}
       />
     )
-    const title = screen.getByText('Exiting beta version')
-    const caption = screen.getByText(
-      'Thank you for trying the beta version. You are now returning to My Service Canada Account home page.'
-    )
+    const title = screen.getByText('Test Title')
+    const description = screen.getByText('Test Description')
+    const primaryBtnText = screen.getByText('Test Primary Text')
+    const secondaryBtnText = screen.getByText('Test Secondary Text')
     expect(title).toBeInTheDocument()
-    expect(caption).toBeInTheDocument()
+    expect(description).toBeInTheDocument()
+    expect(primaryBtnText).toBeInTheDocument()
+    expect(secondaryBtnText).toBeInTheDocument()
   })
   it('has no a11y viollations', async () => {
     const { container } = render(
@@ -27,6 +37,14 @@ describe('Exit Beta Modal', () => {
         closeModal={() => {}}
         closeModalAria={'close'}
         continueLink="/"
+        popupId={'Test Id'}
+        popupTitle={'Test Title'}
+        popupDescription={'Test Description'}
+        popupPrimaryBtn={{ id: 'Test Primary Id', text: 'Test Primary Text' }}
+        popupSecondaryBtn={{
+          id: 'Test Secondary Id',
+          text: 'Test Secondary Text',
+        }}
       />
     )
     const results = await axe(container)

--- a/__tests__/pages/my-dashboard.test.js
+++ b/__tests__/pages/my-dashboard.test.js
@@ -30,6 +30,14 @@ jest.mock('../../graphql/mappers/beta-banner-opt-out', () => ({
   },
 }))
 
+jest.mock('../../graphql/mappers/beta-popup-exit', () => ({
+  getBetaPopupExitContent: () => {
+    return new Promise(function (resolve, reject) {
+      resolve({ en: {}, fr: {} })
+    })
+  },
+}))
+
 jest.mock('../../components/Card', () => () => {
   return <mock-card data-testid="mock-card" />
 })
@@ -83,6 +91,7 @@ describe('My Dashboard page', () => {
             title: 'Mon dossier Service Canada - Tableau de Bord',
           },
         },
+        popupContent: {},
       },
     })
   })

--- a/components/ExitBetaModal.js
+++ b/components/ExitBetaModal.js
@@ -9,6 +9,7 @@ export default function ExitBetaModal(props) {
     <div
       className="m-8 sm:mx-24 sm:mt-24 p-4 md:p-16 bg-white rounded h-fit"
       data-cy="exitBetaModal"
+      id={props.popupId}
     >
       <div className="flex justify-between">
         <div
@@ -16,7 +17,7 @@ export default function ExitBetaModal(props) {
           role="heading"
           aria-level="1"
         >
-          Exiting beta version
+          {props.popupTitle}
         </div>
         <button
           data-cy="x-button"
@@ -28,23 +29,22 @@ export default function ExitBetaModal(props) {
         </button>
       </div>
       <p className="text-xl font-display py-4 mr-10">
-        Thank you for trying the beta version. You are now returning to My
-        Service Canada Account home page.
+        {props.popupDescription}
       </p>
       <div className="md:flex mt-8 md:space-x-12 space-y-6 md:space-y-0">
         <Button
           className="w-full block md:w-fit"
-          id={'modal-btn-close'}
+          id={props.popupSecondaryBtn.id}
           styling="secondary"
           onClick={props.closeModal}
-          text="Stay on beta version"
+          text={props.popupSecondaryBtn.text}
         />
         <Link href={props.continueLink}>
           <Button
             className="w-full block md:w-fit"
-            id={'modal-btn-continue'}
+            id={props.popupPrimaryBtn.id}
             styling="primary"
-            text="Exit beta version"
+            text={props.popupPrimaryBtn.text}
           />
         </Link>
       </div>
@@ -67,4 +67,35 @@ ExitBetaModal.propTypes = {
    * Link for page to continue on with after modal confirmation
    */
   continueLink: PropTypes.string,
+
+  /*
+   * Popup id
+   */
+  popupId: PropTypes.string,
+
+  /*
+   * Popup Title
+   */
+  popupTitle: PropTypes.string,
+
+  /*
+   * Popup Text
+   */
+  popupDescription: PropTypes.string,
+
+  /*
+   * Popup Primary Button
+   */
+  popupPrimaryBtn: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+  }),
+
+  /*
+   * Popup Secondary Button
+   */
+  popupSecondaryBtn: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+  }),
 }

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -36,6 +36,7 @@ export default function Layout(props) {
           bannerButtonText={props.bannerContent.bannerButtonText}
           bannerButtonLink={props.bannerContent.bannerButtonLink}
           icon={props.bannerContent.icon}
+          popupContent={props.popupContent}
         ></PhaseBanner>
       )}
       <Header
@@ -121,6 +122,22 @@ Layout.propTypes = {
     bannerButtonText: PropTypes.string.isRequired,
     bannerButtonLink: PropTypes.string.isRequired,
     icon: PropTypes.string.isRequired,
+  }),
+  /*
+   * popupContent
+   */
+  popupContent: PropTypes.shape({
+    popupId: PropTypes.string.isRequired,
+    popupTitle: PropTypes.string.isRequired,
+    popupDescription: PropTypes.string.isRequired,
+    popupPrimaryBtn: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    }),
+    popupSecondaryBtn: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired,
+    }),
   }),
   /*
    * Link of the page in opposite language

--- a/components/PhaseBanner.js
+++ b/components/PhaseBanner.js
@@ -72,6 +72,11 @@ export default function PhaseBanner(props) {
           closeModal={closeModal}
           closeModalAria={props.bannerButtonText}
           continueLink={openModalWithLink.activeLink}
+          popupId={props.popupContent.popupId}
+          popupTitle={props.popupContent.popupTitle}
+          popupDescription={props.popupContent.popupDescription}
+          popupPrimaryBtn={props.popupContent.popupPrimaryBtn}
+          popupSecondaryBtn={props.popupContent.popupSecondaryBtn}
         />
       </Modal>
     </div>
@@ -107,4 +112,20 @@ PhaseBanner.propTypes = {
    * Icon Text
    */
   icon: propTypes.string,
+  /**
+   * Popup content
+   */
+  popupContent: propTypes.shape({
+    popupId: propTypes.string.isRequired,
+    popupTitle: propTypes.string.isRequired,
+    popupDescription: propTypes.string.isRequired,
+    popupPrimaryBtn: propTypes.shape({
+      id: propTypes.string.isRequired,
+      text: propTypes.string.isRequired,
+    }),
+    popupSecondaryBtn: propTypes.shape({
+      id: propTypes.string.isRequired,
+      text: propTypes.string.isRequired,
+    }),
+  }),
 }

--- a/components/PhaseBanner.test.js
+++ b/components/PhaseBanner.test.js
@@ -6,6 +6,31 @@ import PhaseBanner from './PhaseBanner'
 expect.extend(toHaveNoViolations)
 
 describe('PhaseBanner', () => {
+  const popupContent = {
+    scId: 'beta-popup-exit',
+    scHeadingEn: 'Exiting beta version',
+    scHeadingFr: 'Vous quittez la version bêta',
+    scContentEn:
+      'Thank you for trying the beta version. You are now returning to My Service Canada Account home page.',
+    scContentFr:
+      "Merci d'avoir essayé la version bêta. Nous vous redirigeons vers la page d’accueil de Mon dossier Service Canada.",
+    scFragments: [
+      {
+        scId: 'stay-on-beta-version',
+        // scLinkTextAssistiveEn: "Stay on beta version",
+        // scLinkTextAssistiveFr: "Rester sur la version bêta",
+        scLinkTextEn: 'Stay on beta version',
+        scLinkTextFr: 'Rester sur la version bêta',
+      },
+      {
+        scId: 'exit-beta-version',
+        // scLinkTextAssistiveEn: 'Continue to page',
+        // scLinkTextAssistiveFr: 'Continuer vers la page',
+        scLinkTextEn: 'Exit Beta version',
+        scLinkTextFr: 'Quitter la version beta',
+      },
+    ],
+  }
   it('renders PhaseBanner', () => {
     render(
       <PhaseBanner
@@ -16,6 +41,7 @@ describe('PhaseBanner', () => {
         bannerButtonText={'bannerButtonText'}
         bannerButtonLink={'bannerButtonLink'}
         icon={'bell'}
+        popupContent={popupContent}
       ></PhaseBanner>
     )
     const bannerBoldText = screen.getByText('bannerBoldText')
@@ -38,6 +64,7 @@ describe('PhaseBanner', () => {
         bannerButtonText={'bannerButtonText'}
         bannerButtonLink={'bannerButtonLink'}
         icon={'bell'}
+        popupContent={popupContent}
       ></PhaseBanner>
     )
     const results = await axe(container)

--- a/cypress/e2e/PageObjects/ProfilePO.cy.js
+++ b/cypress/e2e/PageObjects/ProfilePO.cy.js
@@ -1,6 +1,5 @@
 /// <reference types="cypress" />
 /// <reference types="cypress" />
-const dashboardPo = require('../PageObjects/dashboardPO.cy')
 
 function LookingFor() {
   return cy.get("[data-cy ='looking-for']")

--- a/cypress/e2e/PageObjects/dashboardPO.cy.js
+++ b/cypress/e2e/PageObjects/dashboardPO.cy.js
@@ -1,6 +1,5 @@
 /// <reference types="cypress" />
 const profilePo = require('../PageObjects/ProfilePO.cy')
-import dashboardData from '../../fixtures/dashboardData.json'
 
 function dashboardHeader() {
   return cy.get('#my-dashboard-heading')

--- a/graphql/mappers/beta-popup-exit.js
+++ b/graphql/mappers/beta-popup-exit.js
@@ -1,0 +1,87 @@
+import clientQuery from '../client'
+
+export async function getBetaPopupExitContent() {
+  const query = require('../queries/beta-popup-exit.graphql')
+  const res = await clientQuery(query)
+
+  const content = res.data.schContentv1ByPath.item || {}
+  const fallbackContent = {
+    scId: 'beta-popup-exit',
+    scHeadingEn: 'Exiting beta version',
+    scHeadingFr: 'Vous quittez la version bêta',
+    scContentEn:
+      'Thank you for trying the beta version. You are now returning to My Service Canada Account home page.',
+    scContentFr:
+      "Merci d'avoir essayé la version bêta. Nous vous redirigeons vers la page d’accueil de Mon dossier Service Canada.",
+    scFragments: [
+      {
+        scId: 'stay-on-beta-version',
+        // scLinkTextAssistiveEn: "Stay on beta version",
+        // scLinkTextAssistiveFr: "Rester sur la version bêta",
+        scLinkTextEn: 'Stay on beta version',
+        scLinkTextFr: 'Rester sur la version bêta',
+      },
+      {
+        scId: 'exit-beta-version',
+        // scLinkTextAssistiveEn: 'Continue to page',
+        // scLinkTextAssistiveFr: 'Continuer vers la page',
+        scLinkTextEn: 'Exit Beta version',
+        scLinkTextFr: 'Quitter la version beta',
+      },
+    ],
+  }
+
+  const mappedPopupExit = {
+    en: {
+      popupId: content.scId || fallbackContent.scId,
+      popupTitle: content.scHeadingEn || fallbackContent.scHeadingEn,
+      popupDescription:
+        content.scContentEn.json[0].content[0].value ||
+        fallbackContent.scContentEn,
+      popupPrimaryBtn: {
+        id:
+          content.scFragments.find((item) => item.scId === 'exit-beta-version')
+            .scId || fallbackContent.scFragments[1].scId,
+        text:
+          content.scFragments.find((item) => item.scId === 'exit-beta-version')
+            .scLinkTextEn || fallbackContent.scFragments[1].scLinkTextEn,
+      },
+      popupSecondaryBtn: {
+        id:
+          content.scFragments.find(
+            (item) => item.scId === 'stay-on-beta-version'
+          ).scId || fallbackContent.scFragments[0].scId,
+        text:
+          content.scFragments.find(
+            (item) => item.scId === 'stay-on-beta-version'
+          ).scLinkTextEn || fallbackContent.scFragments[0].scLinkTextEn,
+      },
+    },
+    fr: {
+      popupId: content.scId || fallbackContent.scId,
+      popupTitle: content.scHeadingFr || fallbackContent.scHeadingFr,
+      popupDescription:
+        content.scContentFr.json[0].content[0].value ||
+        fallbackContent.scContentFr,
+      popupPrimaryBtn: {
+        id:
+          content.scFragments.find((item) => item.scId === 'exit-beta-version')
+            .scId || fallbackContent.scFragments[1].scId,
+        text:
+          content.scFragments.find((item) => item.scId === 'exit-beta-version')
+            .scLinkTextFr || fallbackContent.scFragments[1].scLinkTextFr,
+      },
+      popupSecondaryBtn: {
+        id:
+          content.scFragments.find(
+            (item) => item.scId === 'stay-on-beta-version'
+          ).scId || fallbackContent.scFragments[0].scId,
+        text:
+          content.scFragments.find(
+            (item) => item.scId === 'stay-on-beta-version'
+          ).scLinkTextFr || fallbackContent.scFragments[0].scLinkTextFr,
+      },
+    },
+  }
+  return mappedPopupExit
+}

--- a/graphql/mappers/beta-popup-page-not-available.js
+++ b/graphql/mappers/beta-popup-page-not-available.js
@@ -1,0 +1,87 @@
+import clientQuery from '../client'
+
+export async function getBetaPopupNotAvailableContent() {
+  const query = require('../queries/beta-popup-page-not-available.graphql')
+  const res = await clientQuery(query)
+
+  const content = res.data.schContentv1ByPath.item
+  const fallbackContent = {
+    scId: 'beta-popup-page-not-available',
+    scHeadingEn: 'Exiting beta version',
+    scHeadingFr: 'Vous quittez la version bêta',
+    scContentEn:
+      'This page is not yet available in the beta version. You will be transferred to the current My Service Canada Account to view this page.',
+    scContentFr:
+      "Cette page n'est pas encore disponible dans la version bêta. Vous serez transféré à la version actuelle de Mon dossier Service Canada pour la consulter.",
+    scFragments: [
+      {
+        scId: 'stay-on-beta-version',
+        // scLinkTextAssistiveEn: "Stay on beta version",
+        // scLinkTextAssistiveFr: "Rester sur la version bêta",
+        scLinkTextEn: 'Stay on beta version',
+        scLinkTextFr: 'Rester sur la version bêta',
+      },
+      {
+        scId: 'continue-to-page',
+        // scLinkTextAssistiveEn: 'Continue to page',
+        // scLinkTextAssistiveFr: 'Continuer vers la page',
+        scLinkTextEn: 'Continue to page',
+        scLinkTextFr: 'Continuer vers la page',
+      },
+    ],
+  }
+
+  const mappedPopupNotAvailable = {
+    en: {
+      popupId: content.scId || fallbackContent.scId,
+      popupTitle: content.scHeadingEn || fallbackContent.scHeadingEn,
+      popupDescription:
+        content.scContentEn.json[0].content[0].value ||
+        fallbackContent.scContentEn,
+      popupPrimaryBtn: {
+        id:
+          content.scFragments.find((item) => item.scId === 'continue-to-page')
+            .scId || fallbackContent.scFragments[1].scId,
+        text:
+          content.scFragments.find((item) => item.scId === 'continue-to-page')
+            .scLinkTextEn || fallbackContent.scFragments[1].scLinkTextEn,
+      },
+      popupSecondaryBtn: {
+        id:
+          content.scFragments.find(
+            (item) => item.scId === 'stay-on-beta-version'
+          ).scId || fallbackContent.scFragments[0].scId,
+        text:
+          content.scFragments.find(
+            (item) => item.scId === 'stay-on-beta-version'
+          ).scLinkTextEn || fallbackContent.scFragments[0].scLinkTextEn,
+      },
+    },
+    fr: {
+      popupId: content.scId || fallbackContent.scId,
+      popupTitle: content.scHeadingFr || fallbackContent.scHeadingFr,
+      popupDescription:
+        content.scContentFr.json[0].content[0].value ||
+        fallbackContent.scContentFr,
+      popupPrimaryBtn: {
+        id:
+          content.scFragments.find((item) => item.scId === 'continue-to-page')
+            .scId || fallbackContent.scFragments[1].scId,
+        text:
+          content.scFragments.find((item) => item.scId === 'continue-to-page')
+            .scLinkTextFr || fallbackContent.scFragments[1].scLinkTextFr,
+      },
+      popupSecondaryBtn: {
+        id:
+          content.scFragments.find(
+            (item) => item.scId === 'stay-on-beta-version'
+          ).scId || fallbackContent.scFragments[0].scId,
+        text:
+          content.scFragments.find(
+            (item) => item.scId === 'stay-on-beta-version'
+          ).scLinkTextFr || fallbackContent.scFragments[0].scLinkTextFr,
+      },
+    },
+  }
+  return mappedPopupNotAvailable
+}

--- a/graphql/queries/beta-popup-exit.graphql
+++ b/graphql/queries/beta-popup-exit.graphql
@@ -1,0 +1,27 @@
+{
+  schContentv1ByPath(
+    _path: "/content/dam/decd-endc/content-fragments/sch/content/beta-popup-exit"
+  ) {
+    item {
+      _path
+      scId
+      scHeadingEn
+      scHeadingFr
+      scContentEn{
+          json
+      }
+      scContentFr{
+          json
+      }
+      scFragments{
+          ... on SCHTaskv1Model{
+              scId
+              scLinkTextAssistiveEn
+              scLinkTextAssistiveFr
+              scLinkTextEn
+              scLinkTextFr
+          }
+      }
+    }
+  }
+}

--- a/graphql/queries/beta-popup-page-not-available.graphql
+++ b/graphql/queries/beta-popup-page-not-available.graphql
@@ -1,0 +1,27 @@
+{
+  schContentv1ByPath(
+    _path: "/content/dam/decd-endc/content-fragments/sch/content/beta-popup-page-not-available"
+  ) {
+    item {
+      _path
+      scId
+      scHeadingEn
+      scHeadingFr
+      scContentEn{
+          json
+      }
+      scContentFr{
+          json
+      }
+      scFragments{
+          ... on SCHTaskv1Model{
+              scId
+              scLinkTextAssistiveEn
+              scLinkTextAssistiveFr
+              scLinkTextEn
+              scLinkTextFr
+          }
+      }
+    }
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -15,6 +15,7 @@ export default function MyApp({ Component, pageProps }) {
       langToggleLink={pageProps.langToggleLink}
       breadCrumbItems={pageProps.breadCrumbItems}
       bannerContent={pageProps.bannerContent}
+      popupContent={pageProps.popupContent}
       display={display}
     >
       <Component {...pageProps} />

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -5,6 +5,8 @@ import fr from '../locales/fr'
 import Card from '../components/Card'
 import { getMyDashboardContent } from '../graphql/mappers/my-dashboard'
 import { getBetaBannerContent } from '../graphql/mappers/beta-banner-opt-out'
+import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
+import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-page-not-available'
 import logger from '../lib/logger'
 import BenefitTasks from './../components/BenefitTasks'
 import MostReqTasks from './../components/MostReqTasks'
@@ -96,6 +98,22 @@ export async function getServerSideProps({ res, locale }) {
     // res.statusCode = 500
     throw error
   })
+  const popupContent = await getBetaPopupExitContent().catch((error) => {
+    logger.error(error)
+    // res.statusCode = 500
+    throw error
+  })
+
+  /* 
+  * Uncomment this block to make Banner Popup Content display "Page Not Available"
+  * Comment "getBetaPopupExitContent()" block of code above.
+  
+    const popupContent = await getBetaPopupNotAvailableContent().catch((error) => {
+      logger.error(error)
+      // res.statusCode = 500
+      throw error
+    })
+  */
 
   /* istanbul ignore next */
   const langToggleLink = locale === 'en' ? '/fr/my-dashboard' : '/my-dashboard'
@@ -123,6 +141,7 @@ export async function getServerSideProps({ res, locale }) {
       content: locale === 'en' ? content.en : content.fr,
       meta,
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
+      popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
     },
   }
 }

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -6,6 +6,8 @@ import fr from '../locales/fr'
 import Card from '../components/Card'
 import { getProfileContent } from '../graphql/mappers/profile'
 import { getBetaBannerContent } from '../graphql/mappers/beta-banner-opt-out'
+import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
+import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-page-not-available'
 import logger from '../lib/logger'
 import ProfileTasks from './../components/ProfileTasks'
 import Modal from 'react-modal'
@@ -95,6 +97,22 @@ export async function getStaticProps({ res, locale }) {
     // res.statusCode = 500
     throw error
   })
+  const popupContent = await getBetaPopupExitContent().catch((error) => {
+    logger.error(error)
+    // res.statusCode = 500
+    throw error
+  })
+
+  /* 
+   * Uncomment this block to make Banner Popup Content display "Page Not Available"
+   * Comment "getBetaPopupExitContent()" block of code above.
+  
+    const popupContent = await getBetaPopupNotAvailableContent().catch((error) => {
+      logger.error(error)
+      // res.statusCode = 500
+      throw error
+    })
+  */
 
   /* istanbul ignore next */
   const langToggleLink = locale === 'en' ? '/fr/profile' : '/profile'
@@ -132,6 +150,7 @@ export async function getStaticProps({ res, locale }) {
       meta,
       breadCrumbItems,
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
+      popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
     },
   }
 }

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -5,6 +5,8 @@ import en from '../locales/en'
 import fr from '../locales/fr'
 import { getSecuritySettingsContent } from '../graphql/mappers/security-settings'
 import { getBetaBannerContent } from '../graphql/mappers/beta-banner-opt-out'
+import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
+import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-page-not-available'
 import logger from '../lib/logger'
 
 export default function SecuritySettings(props) {
@@ -59,6 +61,23 @@ export async function getStaticProps({ res, locale }) {
     // res.statusCode = 500
     throw error
   })
+  const popupContent = await getBetaPopupExitContent().catch((error) => {
+    logger.error(error)
+    // res.statusCode = 500
+    throw error
+  })
+
+  /* 
+   * Uncomment this block to make Banner Popup Content display "Page Not Available"
+   * Comment "getBetaPopupExitContent()" block of code above.
+  
+    const popupContent = await getBetaPopupNotAvailableContent().catch((error) => {
+      logger.error(error)
+      // res.statusCode = 500
+      throw error
+    })
+  */
+
   /* istanbul ignore next */
   const langToggleLink =
     locale === 'en' ? '/fr/security-settings' : '/security-settings'
@@ -96,6 +115,7 @@ export async function getStaticProps({ res, locale }) {
       meta,
       breadCrumbItems,
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
+      popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
     },
   }
 }


### PR DESCRIPTION
### Description

List of proposed changes:

- Adding all AEM content.


### What to test for/How to test

- To test *exit-beta-popup*
- Click exit beta button in both french and english. (Content should be the same as in aem)

![image](https://user-images.githubusercontent.com/77116011/202789005-f0ab174a-d10c-425c-bd5c-2e6bdb42f071.png)

- To test *beta-popup-page-not-available*
- Comment out this block of code in the dashboard page (Line 101):
```  
const popupContent = await getBetaPopupExitContent().catch((error) => {
    logger.error(error)
    // res.statusCode = 500
    throw error
  })
```
- Uncomment the block of code below:
```
const popupContent = await getBetaPopupNotAvailableContent().catch((error) => {
      logger.error(error)
      // res.statusCode = 500
      throw error
    })
```

![image](https://user-images.githubusercontent.com/77116011/202789471-a08f40a0-0a63-461d-b4ef-e277048bcd45.png)

