### PR TITLE
86051 Fixes FA icon flash for all icons in prod

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,8 @@
 import '../styles/globals.css'
 import Layout from '../components/Layout'
+import { config } from '@fortawesome/fontawesome-svg-core'
+import '@fortawesome/fontawesome-svg-core/styles.css'
+config.autoAddCss = false
 
 export default function MyApp({ Component, pageProps }) {
   /* istanbul ignore next */


### PR DESCRIPTION
## [ADO-86051](https://dev.azure.com/VP-BD/DECD/_workitems/edit/86051)

### Description

List of proposed changes:

- There was a small flash of large unstyled FA icons on page load in the production build. This should force them all to wait for styling.

### What to test for/How to test
- Shouldn't see an icon flash in the prod build

### Additional Notes
