### PR TITLE
96052 trigger modal after time

### DIFF
--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -1,6 +1,6 @@
 import CountDown from '../components/sessionModals/CountDown'
 import SignedOut from '../components/sessionModals/SignedOut'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Heading, Button } from '@dts-stn/service-canada-design-system'
 import en from '../locales/en'
@@ -26,6 +26,11 @@ export default function MyDashboard(props) {
     isOpen: false,
     activeLink: '/',
   })
+  const currentDate = new Date()
+  const [expires, setExpires] = useState({
+    warning: new Date(currentDate.getTime() + 1 * 10 * 1000),
+    logout: new Date(currentDate.getTime() + 2 * 10 * 1000),
+  })
 
   const [demoModalBody, setDemoModalBody] = useState(null)
 
@@ -44,6 +49,17 @@ export default function MyDashboard(props) {
   function closeModal() {
     setOpenModalWithLink({ isOpen: false, activeLink: '/' })
   }
+
+  useEffect(() => {
+    const id = setInterval(function () {
+      if (new Date() >= expires.warning) {
+        demoContent(
+          new Date() >= expires.logout ? <SignedOut /> : <CountDown />
+        )
+      } else return
+    }, 1000)
+    return () => clearInterval(id)
+  }, [])
 
   return (
     <div id="myDashboardContent" data-testid="myDashboardContent-test">

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -17,6 +17,7 @@ import MostReqTasks from './../components/MostReqTasks'
 import Modal from 'react-modal'
 import React from 'react'
 import ExitBetaModal from '../components/ExitBetaModal'
+import Router from 'next/router'
 
 export default function MyDashboard(props) {
   /* istanbul ignore next */
@@ -28,8 +29,9 @@ export default function MyDashboard(props) {
   })
   const currentDate = new Date()
   const [expires, setExpires] = useState({
-    warning: new Date(currentDate.getTime() + 1 * 10 * 1000),
-    logout: new Date(currentDate.getTime() + 2 * 10 * 1000),
+    warning: new Date(currentDate.getTime() + 1 * 60 * 1000),
+    logout: new Date(currentDate.getTime() + 2 * 60 * 1000),
+    active: false,
   })
 
   const [demoModalBody, setDemoModalBody] = useState(null)
@@ -52,14 +54,35 @@ export default function MyDashboard(props) {
 
   useEffect(() => {
     const id = setInterval(function () {
-      if (new Date() >= expires.warning) {
+      if (new Date() >= expires.warning && expires.active) {
         demoContent(
-          new Date() >= expires.logout ? <SignedOut /> : <CountDown />
+          new Date() >= expires.logout ? (
+            <SignedOut
+              closeModal={closeDemoModal}
+              onContinue={() => Router.push('./')}
+              id="SignedOut"
+              {...props.popupYouHaveBeenSignedout}
+            />
+          ) : (
+            <CountDown
+              closeModal={closeDemoModal}
+              onSignOut={() => Router.push('./')}
+              onStay={() => {
+                setExpires((t) => {
+                  return { ...t, warning: t.logout }
+                })
+                setDemoModalBody(null)
+              }}
+              id="CountDown"
+              deadline={expires.logout}
+              {...props.popupStaySignedIn}
+            />
+          )
         )
       } else return
     }, 1000)
     return () => clearInterval(id)
-  }, [])
+  }, [expires])
 
   return (
     <div id="myDashboardContent" data-testid="myDashboardContent-test">
@@ -102,40 +125,6 @@ export default function MyDashboard(props) {
           </Card>
         )
       })}
-
-      <Button
-        text="Countdown"
-        styling="primary"
-        className="mr-3  m-5"
-        onClick={() =>
-          demoContent(
-            <CountDown
-              closeModal={closeDemoModal}
-              onSignOut={() => console.log('Sign Out Clicked')}
-              onStay={() => console.log('Stay Signed In Clicked')}
-              id="CountDown"
-              deadline="January, 31, 2023"
-              {...props.popupStaySignedIn}
-            />
-          )
-        }
-      />
-
-      <Button
-        text="Signed Out"
-        styling="primary"
-        className="mr-3 m-5"
-        onClick={() =>
-          demoContent(
-            <SignedOut
-              closeModal={closeDemoModal}
-              onContinue={() => console.log('Continue Clicked')}
-              id="SignedOut"
-              {...props.popupYouHaveBeenSignedout}
-            />
-          )
-        }
-      />
 
       <Modal
         className="flex justify-center bg-black/75 h-full"


### PR DESCRIPTION
## [ADO-96052](https://dev.azure.com/VP-BD/DECD/_workitems/edit/XXX)

### Description

List of proposed changes:

- Coundown and Signout modals trigger on dashboard page after 1 and 2 minutes respectively. 
- In order to trigger modals, expires.active variable must be set to true. Timer is deactivated by default. 

### What to test for/How to test

### Additional Notes
