### PR TITLE
updated the spacing slightly

### DIFF
--- a/components/contact/ContactProvinceRow.js
+++ b/components/contact/ContactProvinceRow.js
@@ -16,9 +16,9 @@ const ContactProvinceRow = ({ label, items, id }) => {
         >
           {items.map((x, i) => (
             <div className="col-span-2 md:col-span-1 py-3" key={i}>
-              <span className="prose prose-strong:text-xl prose-strong:font-display">
+              <strong className="prose prose-strong:text-xl prose-strong:font-display prose-p:text-xl prose-p:font-display">
                 <Markdown>{`${ap(x.content, ' ')}`}</Markdown>
-              </span>
+              </strong>
               {x && (
                 <Markdown>{`${ap(x.recipient, '\n\n')}${ap(
                   x.program,

--- a/cypress/e2e/SecuritySettings.cy.js
+++ b/cypress/e2e/SecuritySettings.cy.js
@@ -86,7 +86,7 @@ describe('Validate Security Settings page', () => {
     profilePo.LookingFor().should('have.text', 'Looking for profile settings?')
     profilePo
       .BackToDashboardButton()
-      .should('have.text', 'Back to my Dashboard')
+      .should('have.text', 'Back to my dashboard')
   })
 
   it('Validate the "Looking for Profile Settings text" and button text in French', () => {

--- a/locales/en.js
+++ b/locales/en.js
@@ -41,7 +41,7 @@ export default {
   pageLinkSecurity: 'Looking for security settings?',
   securityLinkText: 'security settings',
   accessYourSecurityText: 'Access your ',
-  backToDashboard: 'Back to my Dashboard',
+  backToDashboard: 'Back to my dashboard',
 
   // ViewMoreLessButton
   viewMoreLessButtonCaption: `Applications, payments and claims, taxes, reports and documents, personal information`,


### PR DESCRIPTION
## [ADO-103251](https://dev.azure.com/VP-BD/DECD/_workitems/edit/103251)
## [ADO-103121](https://dev.azure.com/VP-BD/DECD/_workitems/edit/103121)
Fixes [AB#103121](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/103121)
Fixes [AB#103251](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/103251)
fix: Lower case 'd'. spacing in mail options

### Description
fixed the back to dashboard button to have a lower case d.
Fixed the spacing options for the mail options on the contact us pages. 
Made the titles strong as requested from the a11y team. 

### What to test for/How to test

### Additional Notes
