### PR TITLE
Update link in banner to open in new tab

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -36,6 +36,10 @@ export default function Layout(props) {
           bannerLinkHref={props.bannerContent.bannerLinkHref || ''}
           bannerButtonText={props.bannerContent.bannerButtonText || ''}
           bannerButtonLink={props.bannerContent.bannerButtonLink || ''}
+          bannerButtonExternalText={
+            props.bannerContent.bannerButtonExternalText || ''
+          }
+          bannerButtonExternalLink
           icon={props.bannerContent.icon || ''}
           popupContent={props.popupContent || ''}
         ></PhaseBanner>

--- a/components/PhaseBanner.js
+++ b/components/PhaseBanner.js
@@ -42,8 +42,15 @@ export default function PhaseBanner(props) {
           <a
             href={props.bannerLinkHref}
             className="font-body text-xl text-deep-blue-dark hover:text-blue-hover"
+            target={props.bannerButtonExternalLink ? '_blank' : undefined}
+            rel={
+              props.bannerButtonExternalLink ? 'noopener noreferrer' : undefined
+            }
           >
             <span className="mr-2 underline">{props.bannerLink}</span>
+            {props.bannerButtonExternalLink && (
+              <span className="sr-only">{props.bannerButtonExternalText} </span>
+            )}
             <FontAwesomeIcon
               width="14"
               icon={icon[props.icon]}
@@ -108,6 +115,14 @@ PhaseBanner.propTypes = {
    * Phasebanner Button Href
    */
   bannerButtonHref: propTypes.string,
+  /**
+   * Boolean to determine if the button in the banner links to an external page
+   */
+  bannerButtonExternalLink: propTypes.bool,
+  /**
+   * Screen reader only external link text
+   */
+  bannerButtonExternalText: propTypes.string,
   /**
    * Icon Text
    */

--- a/graphql/mappers/beta-banner-opt-out.js
+++ b/graphql/mappers/beta-banner-opt-out.js
@@ -2,9 +2,12 @@ import clientQuery from '../client'
 
 export async function getBetaBannerContent() {
   const queryOptOut = require('../queries/beta-banner-opt-out.graphql')
+  const queryDictionary = require('../queries/dictionary.graphql')
   const resOptOut = await clientQuery(queryOptOut)
+  const resDictionary = await clientQuery(queryDictionary)
 
   const resOptOutContent = resOptOut.data.schContentv1ByPath.item || {}
+  const resDictionaryContent = resDictionary.data.dictionaryV1List.items || {}
 
   const mappedBanner = {
     en: {
@@ -13,6 +16,9 @@ export async function getBetaBannerContent() {
       bannerLink: resOptOutContent.scFragments[0].scLinkTextEn,
       bannerLinkHref: resOptOutContent.scFragments[0].scDestinationURLEn,
       bannerButtonText: resOptOutContent.scFragments[1].scLinkTextEn,
+      bannerButtonExternalText: resDictionaryContent.filter(
+        (entry) => entry.scId === 'opens-in-a-new-tab'
+      )[0].scTermEn,
       bannerButtonLink:
         resOptOutContent.scFragments[1].scDestinationURLEn || '/',
       icon: resOptOutContent.scFragments[0].scIconCSS,
@@ -23,6 +29,9 @@ export async function getBetaBannerContent() {
       bannerLink: resOptOutContent.scFragments[0].scLinkTextFr,
       bannerLinkHref: resOptOutContent.scFragments[0].scDestinationURLFr,
       bannerButtonText: resOptOutContent.scFragments[1].scLinkTextFr,
+      bannerButtonExternalText: resDictionaryContent.filter(
+        (entry) => entry.scId === 'opens-in-a-new-tab'
+      )[0].scTermFr,
       bannerButtonLink:
         resOptOutContent.scFragments[1].scDestinationURLFr || '/',
       icon: resOptOutContent.scFragments[0].scIconCSS,

--- a/graphql/mappers/beta-banner-opt-out.js
+++ b/graphql/mappers/beta-banner-opt-out.js
@@ -16,9 +16,9 @@ export async function getBetaBannerContent() {
       bannerLink: resOptOutContent.scFragments[0].scLinkTextEn,
       bannerLinkHref: resOptOutContent.scFragments[0].scDestinationURLEn,
       bannerButtonText: resOptOutContent.scFragments[1].scLinkTextEn,
-      bannerButtonExternalText: resDictionaryContent.filter(
+      bannerButtonExternalText: resDictionaryContent.find(
         (entry) => entry.scId === 'opens-in-a-new-tab'
-      )[0].scTermEn,
+      ).scTermEn,
       bannerButtonLink:
         resOptOutContent.scFragments[1].scDestinationURLEn || '/',
       icon: resOptOutContent.scFragments[0].scIconCSS,
@@ -29,9 +29,9 @@ export async function getBetaBannerContent() {
       bannerLink: resOptOutContent.scFragments[0].scLinkTextFr,
       bannerLinkHref: resOptOutContent.scFragments[0].scDestinationURLFr,
       bannerButtonText: resOptOutContent.scFragments[1].scLinkTextFr,
-      bannerButtonExternalText: resDictionaryContent.filter(
+      bannerButtonExternalText: resDictionaryContent.find(
         (entry) => entry.scId === 'opens-in-a-new-tab'
-      )[0].scTermFr,
+      ).scTermFr,
       bannerButtonLink:
         resOptOutContent.scFragments[1].scDestinationURLFr || '/',
       icon: resOptOutContent.scFragments[0].scIconCSS,

--- a/graphql/queries/dictionary.graphql
+++ b/graphql/queries/dictionary.graphql
@@ -1,0 +1,10 @@
+{
+  dictionaryV1List {
+    items {
+      _path
+      scId
+      scTermEn
+      scTermFr
+    }
+  }
+}


### PR DESCRIPTION
## [ADO-107391](https://dev.azure.com/VP-BD/DECD/_workitems/edit/107391)

### Description
This PR updates the link in the banner to open in a new tab. In doing so, it also became necessary to add sr-only text to alert screen readers that the link is external. To do this, I've added a new query for the dictionary, and filter through it for the external link text in the opt out banner mapper. The dictionary can potentially also be used for other terms in the future.

Fixes [AB#107391](https://dev.azure.com/VP-BD/DECD/_workitems/edit/107391)

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. You can either fire up a screen reader and navigate to the link in the banner to hear it say `opens in a new tab` or remove the `sr-only` class to see that the text is present