### PR TITLE
Update ContactSection & ContactSectionRow to contain a dl

### DIFF
--- a/__tests__/components/contact/ContactSection.test.js
+++ b/__tests__/components/contact/ContactSection.test.js
@@ -8,8 +8,26 @@ expect.extend(toHaveNoViolations)
 describe('ContactSection', () => {
   it('renders contactSection', () => {
     const primary = render(
-      <ContactSection {...ContactSection.args} details={[]} intro="" />
+      <ContactSection
+        {...ContactSection.args}
+        details={[]}
+        intro=""
+        title="Test title"
+      />
     )
     expect(primary).toBeTruthy()
+  })
+
+  it('has no a11y violations', async () => {
+    const { container } = render(
+      <ContactSection
+        {...ContactSection.args}
+        details={[]}
+        intro=""
+        title="test title"
+      />
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
   })
 })

--- a/__tests__/components/contact/ContactSectionRow.test.js
+++ b/__tests__/components/contact/ContactSectionRow.test.js
@@ -10,4 +10,12 @@ describe('ContactSectionRow', () => {
     const primary = render(<ContactSectionRow {...ContactSectionRow.args} />)
     expect(primary).toBeTruthy()
   })
+
+  it('has no a11y violations', async () => {
+    const { container } = render(
+      <ContactSectionRow {...ContactSectionRow.args} />
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
 })

--- a/components/contact/ContactSection.js
+++ b/components/contact/ContactSection.js
@@ -19,7 +19,7 @@ export default function ContactSection({ title, intro, id, details }) {
       >
         <Markdown>{intro}</Markdown>
       </div>
-      <section className=" border-y-2 divide-y-2 " data-cy="section2">
+      <dl className=" border-y-2 divide-y-2 " data-cy="section2">
         {details.map((x, index) =>
           ContactSectionRow({
             ...x,
@@ -32,7 +32,7 @@ export default function ContactSection({ title, intro, id, details }) {
             buttonURL: x.items[0].link,
           })
         )}
-      </section>
+      </dl>
       <div className="mt-4  pb-6" />
     </div>
   )

--- a/components/contact/ContactSectionRow.js
+++ b/components/contact/ContactSectionRow.js
@@ -23,14 +23,14 @@ function ContactSectionRow(props) {
   }
   return label && detail ? (
     <div className={`grid grid-cols-1 md:grid-cols-12 py-2 ${''}`} key={index}>
-      <div
+      <dt
         className={`md:col-span-4 font-bold font-body text-2xl md:pl-3 ${
           highlight && 'bg-blue-100 py-2'
         }`}
       >
         {label}
-      </div>
-      <div
+      </dt>
+      <dd
         className={`md:col-span-8 prose max-w-none prose-p:font-body prose-p:text-xl prose-p:my-0  ${
           highlight && 'bg-blue-100 py-2'
         }`}
@@ -54,7 +54,7 @@ function ContactSectionRow(props) {
             <Markdown>{detail}</Markdown>
           </div>
         )}
-      </div>
+      </dd>
     </div>
   ) : (
     <Fragment key={index} />


### PR DESCRIPTION
## [ADO-102881](https://dev.azure.com/VP-BD/DECD/_workitems/edit/102881)

### Description
This PR update the `ContactSection` component to be a `<dl>` and the `ContactSectionRow` component to contain `<dt>` and `<dd>` tags. Description lists use to have a restriction where they could only contain their child elements ( `<dt>` and `<dd>`) but it is now also valid for them to have divs as child elements as long as those divs contain  `<dt>` and `<dd>` elements.

This fixes [AB#102881](https://dev.azure.com/VP-BD/DECD/_workitems/edit/102881)

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to any of the contact pages
4. Inspect the tables to ensure that they are definition lists and contain definition terms and descriptions

### Additional Notes
This PR does not address the change to the "Before you call/contact/come in" being changed to h3s since that still needs to be mulled over by Breanna and design.
