### PR TITLE
Update Apollo client to 3.7.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@apollo/client": "^3.7.4",
+        "@apollo/client": "^3.7.8",
         "@dts-stn/service-canada-design-system": "^1.56.6-dev.7e188efb1",
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-regular-svg-icons": "^6.2.0",
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.4.tgz",
-      "integrity": "sha512-bgiCKRmLSBImX4JRrw8NjqGo0AQE/mowCdHX1PJp2r5zIXrJx0UeaAYmx1qJY69Oz/KR7SKlLt4xK+bOP1jx7A==",
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.8.tgz",
+      "integrity": "sha512-o1NxF4ytET2w9HSVMLwYUEEdv6H3XPpbh9M+ABVGnUVT0s6T9pgqRtYO4pFP1TmeDmb1pbRfVhFwh3gC167j5Q==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.7.0",
@@ -19622,9 +19622,9 @@
       }
     },
     "@apollo/client": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.4.tgz",
-      "integrity": "sha512-bgiCKRmLSBImX4JRrw8NjqGo0AQE/mowCdHX1PJp2r5zIXrJx0UeaAYmx1qJY69Oz/KR7SKlLt4xK+bOP1jx7A==",
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.8.tgz",
+      "integrity": "sha512-o1NxF4ytET2w9HSVMLwYUEEdv6H3XPpbh9M+ABVGnUVT0s6T9pgqRtYO4pFP1TmeDmb1pbRfVhFwh3gC167j5Q==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "proxystart": "kubectl port-forward $(kubectl get pods -n squidproxy | awk '{print $1}' | grep squidproxy) 3128:3128 -n squidproxy"
   },
   "dependencies": {
-    "@apollo/client": "^3.7.4",
+    "@apollo/client": "^3.7.8",
     "@dts-stn/service-canada-design-system": "^1.56.6-dev.7e188efb1",
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "@fortawesome/free-regular-svg-icons": "^6.2.0",


### PR DESCRIPTION
### Description
This PR updates Apollo to the latest version. #224 has merge conflicts so i figured rather than go through the trouble fixing those for an outdated version, I'd update to the newest version instead.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Confirm app works as expected
