### PR TITLE
Update metadata title orientation

### DIFF
--- a/__tests__/pages/contact-canada-pension-plan.test.js
+++ b/__tests__/pages/contact-canada-pension-plan.test.js
@@ -141,19 +141,19 @@ describe('CPP Contact Us Page', () => {
         locale: 'en',
         meta: {
           data_en: {
+            title: 'Contact Canada Pension Plan - My Service Canada Account',
             desc: 'English',
             author: 'Service Canada',
             keywords: '',
-            title: 'My Service Canada Account - Contact Canada Pension Plan',
             service: 'ESDC-EDSC_MSCA-MSDC',
             creator: 'Employment and Social Development Canada',
             accessRights: '1',
           },
           data_fr: {
-            author: 'Service Canada',
+            title: 'Régime de Pensions du Canada - Mon dossier Service Canada',
             desc: 'Français',
+            author: 'Service Canada',
             keywords: '',
-            title: 'Mon dossier Service Canada - Régime de Pensions du Canada',
             service: 'ESDC-EDSC_MSCA-MSDC',
             creator: 'Emploi et Développement social Canada',
             accessRights: '1',

--- a/__tests__/pages/contact-employment-insurance.test.js
+++ b/__tests__/pages/contact-employment-insurance.test.js
@@ -71,16 +71,22 @@ describe('EI Contact Us Page', () => {
 
   const meta = {
     data_en: {
-      title: 'My Service Canada Account - Contact Employment Insurance',
+      title: 'Contact Employment Insurance - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
+      service: 'ESDC-EDSC_MSCA-MSDC',
+      creator: 'Employment and Social Development Canada',
+      accessRights: '1',
     },
     data_fr: {
-      title: 'Mon dossier Service Canada - Contactez Assurance Emploi',
+      title: 'Contactez Assurance Emploi - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',
+      service: 'ESDC-EDSC_MSCA-MSDC',
+      creator: 'Emploi et Développement social Canada',
+      accessRights: '1',
     },
   }
 
@@ -141,19 +147,19 @@ describe('EI Contact Us Page', () => {
         locale: 'en',
         meta: {
           data_en: {
+            title: 'Contact Employment Insurance - My Service Canada Account',
             desc: 'English',
             author: 'Service Canada',
             keywords: '',
-            title: 'My Service Canada Account - Contact Employment Insurance',
             service: 'ESDC-EDSC_MSCA-MSDC',
             creator: 'Employment and Social Development Canada',
             accessRights: '1',
           },
           data_fr: {
-            author: 'Service Canada',
+            title: 'Contactez Assurance Emploi - Mon dossier Service Canada',
             desc: 'Français',
+            author: 'Service Canada',
             keywords: '',
-            title: 'Mon dossier Service Canada - Contactez Assurance Emploi',
             service: 'ESDC-EDSC_MSCA-MSDC',
             creator: 'Emploi et Développement social Canada',
             accessRights: '1',

--- a/__tests__/pages/contact-old-age-security.test.js
+++ b/__tests__/pages/contact-old-age-security.test.js
@@ -71,17 +71,23 @@ describe('OAS Contact Us Page', () => {
 
   const meta = {
     data_en: {
-      title: 'My Service Canada Account - Contact Old Age Security',
+      title: 'Contact Old Age Security - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
+      service: 'ESDC-EDSC_MSCA-MSDC',
+      creator: 'Employment and Social Development Canada',
+      accessRights: '1',
     },
     data_fr: {
       title:
-        'Mon dossier Service Canada - Communiquer avec la Sécurité de la vieillesse',
+        'Communiquer avec la Sécurité de la vieillesse - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',
+      service: 'ESDC-EDSC_MSCA-MSDC',
+      creator: 'Emploi et Développement social Canada',
+      accessRights: '1',
     },
   }
 
@@ -142,20 +148,20 @@ describe('OAS Contact Us Page', () => {
         locale: 'en',
         meta: {
           data_en: {
+            title: 'Contact Old Age Security - My Service Canada Account',
             desc: 'English',
             author: 'Service Canada',
             keywords: '',
-            title: 'My Service Canada Account - Contact Old Age Security',
             service: 'ESDC-EDSC_MSCA-MSDC',
             creator: 'Employment and Social Development Canada',
             accessRights: '1',
           },
           data_fr: {
-            author: 'Service Canada',
-            desc: 'Français',
-            keywords: '',
             title:
-              'Mon dossier Service Canada - Communiquer avec la Sécurité de la vieillesse',
+              'Communiquer avec la Sécurité de la vieillesse - Mon dossier Service Canada',
+            desc: 'Français',
+            author: 'Service Canada',
+            keywords: '',
             service: 'ESDC-EDSC_MSCA-MSDC',
             creator: 'Emploi et Développement social Canada',
             accessRights: '1',

--- a/__tests__/pages/my-dashboard.test.js
+++ b/__tests__/pages/my-dashboard.test.js
@@ -131,19 +131,19 @@ describe('My Dashboard page', () => {
         locale: 'en',
         meta: {
           data_en: {
+            title: 'Dashboard - My Service Canada Account',
             desc: 'English',
             author: 'Service Canada',
             keywords: '',
-            title: 'My Service Canada Account - Dashboard',
             service: 'ESDC-EDSC_MSCA-MSDC',
             creator: 'Employment and Social Development Canada',
             accessRights: '1',
           },
           data_fr: {
-            author: 'Service Canada',
+            title: 'Tableau de Bord - Mon dossier Service Canada',
             desc: 'Français',
+            author: 'Service Canada',
             keywords: '',
-            title: 'Mon dossier Service Canada - Tableau de Bord',
             service: 'ESDC-EDSC_MSCA-MSDC',
             creator: 'Emploi et Développement social Canada',
             accessRights: '1',

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -82,7 +82,7 @@ export async function getStaticProps({ res, err }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: `My Service Canada Account - ${statusCode}.`,
+      title: `${statusCode} - My Service Canada Account`,
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -91,7 +91,7 @@ export async function getStaticProps({ res, err }) {
       accessRights: '1',
     },
     data_fr: {
-      title: `Mon dossier Service Canada - ${statusCode}.`,
+      title: `${statusCode} - Mon dossier Service Canada`,
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/contact-us.js
+++ b/pages/contact-us.js
@@ -78,7 +78,7 @@ export async function getServerSideProps({ res, locale }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: 'My Service Canada Account - Contact',
+      title: 'Contact - My Service Canada Account - Contact',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -87,7 +87,7 @@ export async function getServerSideProps({ res, locale }) {
       accessRights: '1',
     },
     data_fr: {
-      title: 'Mon dossier Service Canada - Contactez-nous',
+      title: 'Contactez-nous - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/contact-us/contact-canada-pension-plan.js
+++ b/pages/contact-us/contact-canada-pension-plan.js
@@ -118,7 +118,7 @@ export async function getServerSideProps({ res, locale }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: 'My Service Canada Account - Contact Canada Pension Plan',
+      title: 'Contact Canada Pension Plan - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -127,7 +127,7 @@ export async function getServerSideProps({ res, locale }) {
       accessRights: '1',
     },
     data_fr: {
-      title: 'Mon dossier Service Canada - Régime de Pensions du Canada',
+      title: 'Régime de Pensions du Canada - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/contact-us/contact-employment-insurance.js
+++ b/pages/contact-us/contact-employment-insurance.js
@@ -117,7 +117,7 @@ export async function getServerSideProps({ res, locale }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: 'My Service Canada Account - Contact Employment Insurance',
+      title: 'Contact Employment Insurance - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -126,7 +126,7 @@ export async function getServerSideProps({ res, locale }) {
       accessRights: '1',
     },
     data_fr: {
-      title: 'Mon dossier Service Canada - Contactez Assurance Emploi',
+      title: 'Contactez Assurance Emploi - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/contact-us/contact-old-age-security.js
+++ b/pages/contact-us/contact-old-age-security.js
@@ -109,7 +109,7 @@ export async function getServerSideProps({ res, locale }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: 'My Service Canada Account - Contact Old Age Security',
+      title: 'Contact Old Age Security - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -119,7 +119,7 @@ export async function getServerSideProps({ res, locale }) {
     },
     data_fr: {
       title:
-        'Mon dossier Service Canada - Communiquer avec la Sécurité de la vieillesse',
+        'Communiquer avec la Sécurité de la vieillesse - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -199,7 +199,7 @@ export async function getServerSideProps({ req, res, locale }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: 'My Service Canada Account - Dashboard',
+      title: 'Dashboard - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -208,7 +208,7 @@ export async function getServerSideProps({ req, res, locale }) {
       accessRights: '1',
     },
     data_fr: {
-      title: 'Mon dossier Service Canada - Tableau de Bord',
+      title: 'Tableau de Bord - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -123,7 +123,7 @@ export async function getServerSideProps({ res, locale }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: 'My Service Canada Account - Profile',
+      title: 'Profile - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -132,7 +132,7 @@ export async function getServerSideProps({ res, locale }) {
       accessRights: '1',
     },
     data_fr: {
-      title: 'Mon dossier Service Canada - Profil',
+      title: 'Profil - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -95,7 +95,7 @@ export async function getServerSideProps({ res, locale }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: 'My Service Canada Account - Security',
+      title: 'Security - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -104,7 +104,7 @@ export async function getServerSideProps({ res, locale }) {
       accessRights: '1',
     },
     data_fr: {
-      title: 'Mon dossier Service Canada - Sécurité',
+      title: 'Sécurité - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',


### PR DESCRIPTION
## [ADO-103114](https://dev.azure.com/VP-BD/DECD/_workitems/edit/103114) [ADO-107587](https://dev.azure.com/VP-BD/DECD/_workitems/edit/107587)

### Description
Fixes [AB#107587](https://dev.azure.com/VP-BD/DECD/_workitems/edit/107587)

In this PR, I've updated the title tag for each page so the page name comes first, followed by `My Service Canada Account`. The exception to this is any page that currently has the title as `My Service Canada Account - Canada.ca` as having the Canada.ca first doesn't really make any sense, nor does it look right.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate through the site and ensure each page's title tag has been updated to reflect the format explained above

### Additional Notes
Some of the beta pages didn't have unique metadata, will we be implementing that? Are we eventually going to migrate all of this to AEM?

Currently we don't have a test written for the `contact-us` page, only the child pages. This should be addressed in another PR.
