### PR TITLE
Update DS to fix a11y issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.7.8",
-        "@dts-stn/service-canada-design-system": "^1.56.6-dev.7e188efb1",
+        "@dts-stn/service-canada-design-system": "^1.56.6-dev.d56461a2b",
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-regular-svg-icons": "^6.2.0",
         "@fortawesome/free-solid-svg-icons": "^6.2.0",
@@ -765,11 +765,11 @@
       }
     },
     "node_modules/@dts-stn/service-canada-design-system": {
-      "version": "1.56.6-dev.7e188efb1",
-      "resolved": "https://registry.npmjs.org/@dts-stn/service-canada-design-system/-/service-canada-design-system-1.56.6-dev.7e188efb1.tgz",
-      "integrity": "sha512-hMx+os5Qv4Z1YrReqx560ZZzvU/U78JAlh6sFQn/XhRVw94gG0U9b0oTwiLaW4TYvDgykf8OiXvpWTTpLL+RuA==",
+      "version": "1.56.6-dev.d56461a2b",
+      "resolved": "https://registry.npmjs.org/@dts-stn/service-canada-design-system/-/service-canada-design-system-1.56.6-dev.d56461a2b.tgz",
+      "integrity": "sha512-ZjXFLpHXU4SnGqDioqo4o63iPESmATfDHUQhwt9kxoeqVWzFDkb4Z2mVdaxB4CQjIPWSdOzz8P0pA5DxrcI+jA==",
       "dependencies": {
-        "git-conventional-commits": "^2.1.2",
+        "git-conventional-commits": "^2.5.0",
         "identity-obj-proxy": "^3.0.0",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
@@ -20102,11 +20102,11 @@
       }
     },
     "@dts-stn/service-canada-design-system": {
-      "version": "1.56.6-dev.7e188efb1",
-      "resolved": "https://registry.npmjs.org/@dts-stn/service-canada-design-system/-/service-canada-design-system-1.56.6-dev.7e188efb1.tgz",
-      "integrity": "sha512-hMx+os5Qv4Z1YrReqx560ZZzvU/U78JAlh6sFQn/XhRVw94gG0U9b0oTwiLaW4TYvDgykf8OiXvpWTTpLL+RuA==",
+      "version": "1.56.6-dev.d56461a2b",
+      "resolved": "https://registry.npmjs.org/@dts-stn/service-canada-design-system/-/service-canada-design-system-1.56.6-dev.d56461a2b.tgz",
+      "integrity": "sha512-ZjXFLpHXU4SnGqDioqo4o63iPESmATfDHUQhwt9kxoeqVWzFDkb4Z2mVdaxB4CQjIPWSdOzz8P0pA5DxrcI+jA==",
       "requires": {
-        "git-conventional-commits": "^2.1.2",
+        "git-conventional-commits": "^2.5.0",
         "identity-obj-proxy": "^3.0.0",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.8",
-    "@dts-stn/service-canada-design-system": "^1.56.6-dev.7e188efb1",
+    "@dts-stn/service-canada-design-system": "^1.56.6-dev.d56461a2b",
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "@fortawesome/free-regular-svg-icons": "^6.2.0",
     "@fortawesome/free-solid-svg-icons": "^6.2.0",

--- a/pages/contact-us/contact-canada-pension-plan.js
+++ b/pages/contact-us/contact-canada-pension-plan.js
@@ -39,6 +39,7 @@ export default function ContactCanadaPensionPlan(props) {
         sectionList={props.pageContent.items.map((item, i) => {
           return { name: item.title, link: `#${item.id}` }
         })}
+        lang={props.locale}
       />
 
       {props.pageContent.items.map((item, i) => (

--- a/pages/contact-us/contact-employment-insurance.js
+++ b/pages/contact-us/contact-employment-insurance.js
@@ -40,6 +40,7 @@ export default function ContactEmploymentInsurance(props) {
         sectionList={props.pageContent.items.map((item, i) => {
           return { name: item.title, link: `#${item.id}` }
         })}
+        lang={props.locale}
       />
 
       {props.pageContent.items.map((item, i) => (

--- a/pages/contact-us/contact-old-age-security.js
+++ b/pages/contact-us/contact-old-age-security.js
@@ -34,6 +34,7 @@ export default function ContactOldAgeSecurity(props) {
         sectionList={props.pageContent.items.map((item, i) => {
           return { name: item.title, link: `#${item.id}` }
         })}
+        lang={props.locale}
       />
 
       {props.pageContent.items.map((item, i) => (


### PR DESCRIPTION
## [ADO-107466](https://dev.azure.com/VP-BD/DECD/_workitems/edit/107466) [ADO-102879](https://dev.azure.com/VP-BD/DECD/_workitems/edit/102879)

### Description
This PR updates DS to the newest dev release in order to fix a11y issues. This addresses the `TableContent` component being changed to a heading (and adding French content), and changing the focus styling for the `Contact us` link in the footer so it is visible/passes WCAG AA standards.

Fixes [AB#107466](https://dev.azure.com/VP-BD/DECD/_workitems/edit/107466) and also fixes [AB#102879](https://dev.azure.com/VP-BD/DECD/_workitems/edit/102879)

### What to test for/How to test
1. Pull in branch
2. Type `npm i`
3. Type `npm run dev`
4. On My Dashboard, tab to the contact us link and ensure the focus styling is white. 
5. Click the link and navigate to any of the contact us sub pages
6. Ensure that the table of contents `On this page` is an `<h2>`, is in sentence case and also changes to French text when switching languages.
