### PR TITLE
Bug: fixed profile title not using aem

### DIFF
--- a/pages/profile.js
+++ b/pages/profile.js
@@ -31,7 +31,7 @@ export default function Profile(props) {
   }
   return (
     <div id="homeContent" data-testid="profileContent-test">
-      <Heading id="my-dashboard-heading" title={t.pageHeading.profile} />
+      <Heading id="my-dashboard-heading" title={props.content.pageName} />
       <p className="text-lg mt-2 font-body">{props.content.heading}</p>
       {props.content.list.map((program, index) => {
         return (


### PR DESCRIPTION
### Description
Profile title was using a translation key, changed to use AEM page title

List of proposed changes:
- Profile page now uses aem title
