### PR TITLE
Add callback URL to signIn event

### DIFF
--- a/pages/signedout.js
+++ b/pages/signedout.js
@@ -16,7 +16,9 @@ const Signedout = (props) => {
   useEffect(() => {
     if (!router.isReady) return
     if (!router.query.error) {
-      signIn('ecasProvider')
+      signIn('ecasProvider', {
+        callbackUrl: `${window.location.origin}/my-dashboard`,
+      })
     }
   }, [router.isReady])
   return (


### PR DESCRIPTION
## [ADO-110680](https://dev.azure.com/VP-BD/DECD/_workitems/edit/110680)

### Description
Small PR that adds a callback URL to the next auth `signIn` event, which will properly redirect the user on successful auth to the dashboard.

Fixes [AB#110680](https://dev.azure.com/VP-BD/DECD/_workitems/edit/110680)

### What to test for/How to test
1. Pull in branch
2. Connect to proxy
3. Type `npm run dev`
4. Select language and go through auth flow
5. Upon successful auth you should be redirected to the `/my-dashboard`
