### PR TITLE
updated banner link to point to msca

### DIFF
--- a/graphql/mappers/beta-banner-opt-out.js
+++ b/graphql/mappers/beta-banner-opt-out.js
@@ -1,4 +1,5 @@
 import clientQuery from '../client'
+import { buildLink } from '../../lib/links'
 
 export async function getBetaBannerContent() {
   const queryOptOut = require('../queries/beta-banner-opt-out.graphql')
@@ -20,7 +21,10 @@ export async function getBetaBannerContent() {
         (entry) => entry.scId === 'opens-in-a-new-tab'
       ).scTermEn,
       bannerButtonLink:
-        resOptOutContent.scFragments[1].scDestinationURLEn || '/',
+        buildLink(
+          resOptOutContent.scFragments[1].schURLType,
+          resOptOutContent.scFragments[1].scDestinationURLEn
+        ) || '/',
       icon: resOptOutContent.scFragments[0].scIconCSS,
     },
     fr: {
@@ -33,7 +37,10 @@ export async function getBetaBannerContent() {
         (entry) => entry.scId === 'opens-in-a-new-tab'
       ).scTermFr,
       bannerButtonLink:
-        resOptOutContent.scFragments[1].scDestinationURLFr || '/',
+        buildLink(
+          resOptOutContent.scFragments[1].schURLType,
+          resOptOutContent.scFragments[1].scDestinationURLEn
+        ) || '/',
       icon: resOptOutContent.scFragments[0].scIconCSS,
     },
   }

--- a/graphql/queries/beta-banner-opt-out.graphql
+++ b/graphql/queries/beta-banner-opt-out.graphql
@@ -16,11 +16,12 @@
           scId
           scDestinationURLEn
           scDestinationURLFr
+           schURLType
           scIconCSS
           scLinkTextEn
           scLinkTextFr
           scLinkTextAssistiveEn
-          scLinkTextAssistiveFr
+          scLinkTextAssistiveFr      
         }
       }
     }


### PR DESCRIPTION
## [ADO-115692](https://dev.azure.com/VP-BD/DECD/_workitems/edit/115692)
fix: exit beta button now goes to the correct MSCA page.

### Description
The url in AEM was updated with only the second part and needed to be combined with the env variable
List of proposed changes:
Added schURLType to the query and buttonLink

### What to test for/How to test
click on the exit Beta Version button in the banner
click on Exit beta version button.
the first part of the url should have the msca base url included.
### Additional Notes
