### PR TITLE
AA Prefixes in English only

### DIFF
--- a/__tests__/pages/contact-canada-pension-plan.test.js
+++ b/__tests__/pages/contact-canada-pension-plan.test.js
@@ -139,6 +139,7 @@ describe('CPP Contact Us Page', () => {
         bannerContent: {},
         langToggleLink: '/fr/contactez-nous/communiquer-regime-pensions-canada',
         locale: 'en',
+        aaPrefix: 'ESDC-EDSC:undefined',
         meta: {
           data_en: {
             title: 'Contact Canada Pension Plan - My Service Canada Account',

--- a/__tests__/pages/contact-employment-insurance.test.js
+++ b/__tests__/pages/contact-employment-insurance.test.js
@@ -145,6 +145,7 @@ describe('EI Contact Us Page', () => {
         bannerContent: {},
         langToggleLink: '/fr/contactez-nous/communiquer-assurance-emploi',
         locale: 'en',
+        aaPrefix: 'ESDC-EDSC:undefined',
         meta: {
           data_en: {
             title: 'Contact Employment Insurance - My Service Canada Account',

--- a/__tests__/pages/contact-old-age-security.test.js
+++ b/__tests__/pages/contact-old-age-security.test.js
@@ -153,6 +153,7 @@ describe('OAS Contact Us Page', () => {
         bannerContent: {},
         langToggleLink: '/fr/contactez-nous/communiquer-securite-vieillesse',
         locale: 'en',
+        aaPrefix: 'ESDC-EDSC:undefined',
         meta: {
           data_en: {
             title: 'Contact Old Age Security - My Service Canada Account',

--- a/__tests__/pages/my-dashboard.test.js
+++ b/__tests__/pages/my-dashboard.test.js
@@ -153,6 +153,7 @@ describe('My Dashboard page', () => {
         popupContentNA: {},
         popupYouHaveBeenSignedout: {},
         popupStaySignedIn: {},
+        aaPrefix: 'ESDC-EDSC:undefined',
       },
     })
   })

--- a/components/BackToButton.js
+++ b/components/BackToButton.js
@@ -9,7 +9,7 @@ export default function BackToButton(props) {
           <a
             id={props.buttonId}
             className="inline-block my-4 py-2.5 px-3.5 font-display text-xl rounded bg-gray-30a text-deep-blue-60b hover:bg-gray-50a hover:cursor-pointer focus:ring focus:ring-offset-4 ring-deep-blue-60f"
-            data-gc-analytics-customclick={`ESDC-EDSC:${props.refPageAA}:${props.buttonLinkText}`}
+            data-gc-analytics-customclick={`${props.refPageAA}:${props.buttonLinkText}`}
           >
             {props.buttonLinkText}
           </a>

--- a/components/BenefitTasks.js
+++ b/components/BenefitTasks.js
@@ -47,7 +47,7 @@ export default function BenefitTasks(props) {
                       props.openModal(task.link)
                     }
                   }}
-                  data-gc-analytics-customclick={`ESDC-EDSC:${props.refPageAA} ${props.acronym}:${task.title}`}
+                  data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:${task.title}`}
                   className="flex items-center underline py-1 text-deep-blue-dark hover:text-blue-hover"
                 >
                   <FontAwesomeIcon

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -67,10 +67,9 @@ export default function Layout(props) {
         }}
         isAuthenticated={props.isAuth}
         customLink={Link}
-        dataGcAnalyticsCustomClickInstitutionVariable={`ESDC-EDSC:${
-          props.children.props.content?.heading ||
-          props.children.props.pageContent?.title
-        }`}
+        dataGcAnalyticsCustomClickInstitutionVariable={
+          props.children.props.aaPrefix
+        }
         menuProps={{
           onSignOut: () => {
             signOut({ callbackUrl: process.env.AUTH_ECAS_GLOBAL_LOGOUT_URL })

--- a/components/MostReqTasks.js
+++ b/components/MostReqTasks.js
@@ -24,7 +24,7 @@ export default function MostReqTasks(props) {
                       props.openModal(task.link)
                     }
                   }}
-                  data-gc-analytics-customclick={`ESDC-EDSC:${props.refPageAA} ${props.acronym}:${task.title}`}
+                  data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:${task.title}`}
                   className="flex items-center underline pl-2 text-white hover:text-gray-50a"
                 >
                   <FontAwesomeIcon

--- a/components/PageLink.js
+++ b/components/PageLink.js
@@ -21,7 +21,7 @@ export default function PageLink(props) {
             <a
               id={`link-for-${linkID}`}
               data-cy={props.dataCy}
-              data-gc-analytics-customclick={`ESDC-EDSC:${props.refPageAA}:${props.linkText}`}
+              data-gc-analytics-customclick={`${props.refPageAA}:${props.linkText}`}
               className="text-blue-default hover:text-blue-hover visited:text-purple-medium underline"
             >
               {props.linkText}

--- a/components/ProfileTasks.js
+++ b/components/ProfileTasks.js
@@ -24,7 +24,7 @@ export default function ProfileTasks(props) {
                       props.openModal(task.link)
                     }
                   }}
-                  data-gc-analytics-customclick={`ESDC-EDSC:${props.refPageAA} ${props.acronym}:${task.title}`}
+                  data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:${task.title}`}
                 >
                   <FontAwesomeIcon
                     icon={

--- a/components/ViewMoreLessButton.js
+++ b/components/ViewMoreLessButton.js
@@ -20,13 +20,13 @@ export default function ViewMoreLessButton(props) {
           <FontAwesomeIcon
             icon={solid('circle-chevron-up')}
             className={`text-46px pr-3`}
-            data-gc-analytics-customclick={`ESDC-EDSC:${props.refPageAA} ${props.acronym}:Contract-Diminuer`}
+            data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:Contract-Diminuer`}
           />
         ) : (
           <FontAwesomeIcon
             icon={solid('circle-chevron-down')}
             className={`text-46px pr-3`}
-            data-gc-analytics-customclick={`ESDC-EDSC:${props.refPageAA} ${props.acronym}:Expand-Etendre`}
+            data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:Expand-Etendre`}
           />
         )}
         <span className="text-left underline font-body">{props.caption}</span>

--- a/components/sessionModals/CountDown.js
+++ b/components/sessionModals/CountDown.js
@@ -16,7 +16,7 @@ const Countdown = (props) => {
 
   const getTime = () => {
     const time = Date.parse(props.deadline) - Date.now()
-    console.log(parseInt(minutes), minutes)
+
     setClock((prev) => {
       return {
         ...prev,

--- a/lib/acronym.js
+++ b/lib/acronym.js
@@ -1,24 +1,26 @@
 // These acronyms are used to convert benefit categories into acronyms for AA.
+// For logistical reasons, acronyms should only be returned in English, regardless of language.
+
 export const acronym = (longText) => {
   switch (longText.toLowerCase()) {
     case 'assurance emploi':
-      return 'AE'
+      return 'EI'
     case 'assurance-emploi':
-      return 'AE'
+      return 'EI'
     case 'employment insurance':
       return 'EI'
     case 'canada pension plan':
       return 'CPP'
     case 'régime de pensions du canada':
-      return 'RGPC'
+      return 'CPP'
     case 'old age security and guaranteed income supplement':
       return 'OASGIS'
     case 'old age security':
       return 'OASGIS'
     case 'sécurité de la vieillesse et supplément de revenu garanti':
-      return 'SVSRG'
+      return 'OASGIS'
     case 'sécurité de la vieillesse':
-      return 'SVSRG'
+      return 'OASGIS'
     default:
       return 'UND'
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.7.8",
-        "@dts-stn/service-canada-design-system": "1.57.1-dev.1c2444418 ",
+        "@dts-stn/service-canada-design-system": "1.57.1-dev.1c2444418",
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-regular-svg-icons": "^6.2.0",
         "@fortawesome/free-solid-svg-icons": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.8",
-    "@dts-stn/service-canada-design-system": "1.57.1-dev.1c2444418 ",
+    "@dts-stn/service-canada-design-system": "1.57.1-dev.1c2444418",
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "@fortawesome/free-regular-svg-icons": "^6.2.0",
     "@fortawesome/free-solid-svg-icons": "^6.2.0",

--- a/pages/contact-us.js
+++ b/pages/contact-us.js
@@ -128,6 +128,7 @@ export async function getServerSideProps({ res, locale }) {
       breadCrumbItems,
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
       popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
+      aaPrefix: `ESDC-EDSC:${content.en.heading}`,
     },
   }
 }

--- a/pages/contact-us/contact-canada-pension-plan.js
+++ b/pages/contact-us/contact-canada-pension-plan.js
@@ -164,6 +164,7 @@ export async function getServerSideProps({ res, locale }) {
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
       popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
       pageContent: locale === 'en' ? pageContent.en : pageContent.fr,
+      aaPrefix: `ESDC-EDSC:${pageContent.en.title}`,
     },
   }
 }

--- a/pages/contact-us/contact-employment-insurance.js
+++ b/pages/contact-us/contact-employment-insurance.js
@@ -163,6 +163,7 @@ export async function getServerSideProps({ res, locale }) {
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
       popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
       pageContent: locale === 'en' ? pageContent.en : pageContent.fr,
+      aaPrefix: `ESDC-EDSC:${pageContent.en.title}`,
     },
   }
 }

--- a/pages/contact-us/contact-old-age-security.js
+++ b/pages/contact-us/contact-old-age-security.js
@@ -162,6 +162,7 @@ export async function getServerSideProps({ res, locale }) {
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
       popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
       pageContent: locale === 'en' ? pageContent.en : pageContent.fr,
+      aaPrefix: `ESDC-EDSC:${pageContent.en.title}`,
     },
   }
 }

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -78,7 +78,7 @@ export default function MyDashboard(props) {
             id="CountDown"
             deadline={expires.logout}
             {...props.popupStaySignedIn}
-            refPageAA={props.content.heading}
+            refPageAA={props.aaPrefix}
           />
         )
       } else return
@@ -116,7 +116,7 @@ export default function MyDashboard(props) {
             cardTitle={card.title}
             viewMoreLessCaption={card.dropdownText}
             acronym={acronym(card.title)}
-            refPageAA={props.content.heading}
+            refPageAA={props.aaPrefix}
           >
             <div className="bg-deep-blue-60d" data-cy="most-requested-section">
               <MostReqTasks
@@ -124,7 +124,7 @@ export default function MyDashboard(props) {
                 dataCy="most-requested"
                 openModal={openModal}
                 acronym={acronym(card.title)}
-                refPageAA={props.content.heading}
+                refPageAA={props.aaPrefix}
               />
             </div>
             <div
@@ -139,7 +139,7 @@ export default function MyDashboard(props) {
                       taskList={taskList}
                       dataCy="task-group-list"
                       openModal={openModal}
-                      refPageAA={props.content.heading}
+                      refPageAA={props.aaPrefix}
                     />
                   </div>
                 )
@@ -164,7 +164,7 @@ export default function MyDashboard(props) {
           popupDescription={props.popupContentNA.popupDescription}
           popupPrimaryBtn={props.popupContentNA.popupPrimaryBtn}
           popupSecondaryBtn={props.popupContentNA.popupSecondaryBtn}
-          refPageAA={props.content.heading}
+          refPageAA={props.aaPrefix}
         />
       </Modal>
       <Modal
@@ -250,6 +250,7 @@ export async function getServerSideProps({ req, res, locale }) {
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
       popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
       popupContentNA: locale === 'en' ? popupContentNA.en : popupContentNA.fr,
+      aaPrefix: `ESDC-EDSC:${content.en?.heading || content.en?.title}`,
       popupStaySignedIn:
         locale === 'en'
           ? authModals.mappedPopupStaySignedIn.en

--- a/pages/privacy-notice-terms-conditions.js
+++ b/pages/privacy-notice-terms-conditions.js
@@ -15,6 +15,7 @@ import Markdown from 'markdown-to-jsx'
 
 export default function PrivacyCondition(props) {
   const t = props.locale === 'en' ? en : fr
+
   return (
     <div className="font-body" data-cy="terms-conditions">
       <Heading
@@ -63,6 +64,7 @@ export default function PrivacyCondition(props) {
         buttonHref={t.url_dashboard}
         buttonId="back-to-dashboard-button"
         buttonLinkText={t.backToDashboard}
+        refPageAA={props.aaPrefix}
       />
       <Date id="termsConditionsDateModified" date="20230331" />
     </div>
@@ -142,6 +144,7 @@ export async function getServerSideProps({ res, locale }) {
       breadCrumbItems,
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
       popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
+      aaPrefix: `ESDC-EDSC:${content.en.heading}`,
     },
   }
 }

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -62,7 +62,7 @@ export default function Profile(props) {
             data-testID="profile-task-group-list"
             openModal={openModal}
             data-cy="task"
-            refPageAA={props.content.pageName}
+            refPageAA={props.aaPrefix}
           />
         )
       })}
@@ -76,7 +76,7 @@ export default function Profile(props) {
         buttonHref={props.content.backToDashboard.btnLink}
         buttonId="back-to-dashboard-button"
         buttonLinkText={props.content.backToDashboard.btnText}
-        refPageAA={props.content.pageName}
+        refPageAA={props.aaPrefix}
       ></PageLink>
       <Modal
         className="flex justify-center bg-black/75 h-full"
@@ -93,7 +93,7 @@ export default function Profile(props) {
           popupDescription={props.popupContentNA.popupDescription}
           popupPrimaryBtn={props.popupContentNA.popupPrimaryBtn}
           popupSecondaryBtn={props.popupContentNA.popupSecondaryBtn}
-          refPageAA={props.content.pageName}
+          refPageAA={props.aaPrefix}
         />
       </Modal>
     </div>
@@ -175,6 +175,7 @@ export async function getServerSideProps({ res, locale }) {
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
       popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
       popupContentNA: locale === 'en' ? popupContentNA.en : popupContentNA.fr,
+      aaPrefix: `ESDC-EDSC:${content.en?.pageName}`,
     },
   }
 }

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -61,7 +61,7 @@ export default function SecuritySettings(props) {
         buttonHref={t.url_dashboard}
         buttonId="back-to-dashboard-button"
         buttonLinkText={t.backToDashboard}
-        refPageAA={props.content.heading}
+        refPageAA={props.aaPrefix}
       ></PageLink>
     </div>
   )
@@ -141,6 +141,7 @@ export async function getServerSideProps({ res, locale }) {
       breadCrumbItems,
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
       popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
+      aaPrefix: `ESDC-EDSC:${content.en?.heading}`,
     },
   }
 }


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/VP-BD/DECD/_workitems/edit/XXX)

### Description

List of proposed changes:

- The AA team has requested that all tags have an English prefix, regardless of language. 
-

### What to test for/How to test

 - All "data-gc-analytics-customclick" props should have an English prefix. Ex: "ESDC-EDSC:My dashboard:Expand Menu-Etendre Menu"
 -  Navigate the site in French, and check all customclick props to make sure that their prefix is in English. 
### Additional Notes
