### PR TITLE
mapped details for contact row

### DIFF
--- a/components/contact/ContactSectionRow.js
+++ b/components/contact/ContactSectionRow.js
@@ -35,25 +35,32 @@ function ContactSectionRow(props) {
           highlight && 'bg-blue-100 py-2'
         }`}
       >
-        {button ? (
-          <Button
-            text={detail}
-            styling={'primary'}
-            id={buttonId}
-            onClick={routeToPage}
-          />
-        ) : (
-          <div className="flex align-baseline font-body text-xl px-2 prose prose-li:marker:text-black prose-p:font-body prose-ul:my-0 prose-li:font-body">
-            {iconFeature && (
-              <FontAwesomeIcon
-                className="pr-2 pt-1"
-                style={{ color: '#2572B4' }}
-                icon={icon[iconFeature]}
-              />
-            )}
-            <Markdown>{detail}</Markdown>
-          </div>
-        )}
+        {props.items.map((detail, index) => {
+          return button ? (
+            <Button
+              key={index}
+              text={detail.content}
+              styling={'primary'}
+              id={buttonId}
+              onClick={routeToPage}
+            />
+          ) : (
+            <div
+              key={index}
+              className="flex align-baseline font-body text-xl px-2 prose prose-li:marker:text-black prose-p:font-body prose-ul:my-0 prose-li:font-body even:pt-4"
+            >
+              {iconFeature && (
+                <FontAwesomeIcon
+                  className="pr-2 pt-1"
+                  style={{ color: '#2572B4' }}
+                  icon={icon[iconFeature]}
+                />
+              )}
+
+              <Markdown>{detail.content}</Markdown>
+            </div>
+          )
+        })}
       </dd>
     </div>
   ) : (


### PR DESCRIPTION
## [ADO-103252](https://dev.azure.com/VP-BD/DECD/_workitems/edit/103252)
feat: Added a map to the contact row to allow for more content to be show should there be some"

### Description
Currently only one piece of content was shown in the row for the contact section. 
The hours of operation had 2 pieces.
List of proposed changes:
Added a map to show both pieces of content in the content section rows.

### What to test for/How to test
both items for the Hours of operation are displayed.

### Additional Notes
