### PR TITLE
Sort provinces alphabetically on contact pages

### DIFF
--- a/components/contact/ContactProvince.js
+++ b/components/contact/ContactProvince.js
@@ -2,20 +2,20 @@ import Markdown from 'markdown-to-jsx'
 import ContactProvinceRow from './ContactProvinceRow'
 
 const ContactProvince = ({ title, intro, id, i, details }) => {
-  //Ensure provinces are sorted alphabetically regardless of language
-  details.sort(function (a, b) {
-    return a.label.toLowerCase().localeCompare(b.label.toLowerCase())
-  })
-
   return (
     <div className="max-w-4xl pb-2 md:pb-4" id={id}>
       <h2 className="py-4 md:py-6 text-4xl font-display font-bold">{title}</h2>
       <div className="[&_ul]:list-inside [&_ul]:ml-4 [&_ul]:list-disc pb-4 font-body text-xl">
         <Markdown>{intro}</Markdown>
       </div>
-      {details.map((item, i) => (
-        <ContactProvinceRow {...item} key={i} />
-      ))}
+      {/* Ensure provinces are sorted alphabetically regardless of language */}
+      {details
+        .sort(function (a, b) {
+          return a.label.toLowerCase().localeCompare(b.label.toLowerCase())
+        })
+        .map((item, i) => (
+          <ContactProvinceRow {...item} key={i} />
+        ))}
     </div>
   )
 }

--- a/components/contact/ContactProvince.js
+++ b/components/contact/ContactProvince.js
@@ -2,6 +2,11 @@ import Markdown from 'markdown-to-jsx'
 import ContactProvinceRow from './ContactProvinceRow'
 
 const ContactProvince = ({ title, intro, id, i, details }) => {
+  //Ensure provinces are sorted alphabetically regardless of language
+  details.sort(function (a, b) {
+    return a.label.toLowerCase().localeCompare(b.label.toLowerCase())
+  })
+
   return (
     <div className="max-w-4xl pb-2 md:pb-4" id={id}>
       <h2 className="py-4 md:py-6 text-4xl font-display font-bold">{title}</h2>


### PR DESCRIPTION
## [ADO-113149](https://dev.azure.com/VP-BD/DECD/_workitems/edit/113149)

### Description

Fixes [AB#113149](https://dev.azure.com/VP-BD/DECD/_workitems/edit/113149)

Small PR that sorts through the array of objects containing the provinces for the contact page and sorts them alphabetically regardless of language prior to mapping over the array.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to any contact page, scroll to the bottom where the provinces are and ensure that they are in alphabetical order for both English and French
