### PR TITLE
121071 middleware fix

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,15 +4,22 @@ import { NextRequest, NextResponse } from 'next/server'
 const PUBLIC_FILE = /\.(.*)$/
 
 export async function middleware(req) {
+  const { nextUrl, url } = req
+  const { locale, pathname } = nextUrl
   if (
-    req.nextUrl.pathname.startsWith('/_next') ||
-    req.nextUrl.pathname.includes('/api/') ||
-    PUBLIC_FILE.test(req.nextUrl.pathname)
+    pathname.startsWith('/_next') ||
+    pathname.includes('/api/') ||
+    PUBLIC_FILE.test(pathname)
   ) {
     return
   }
 
-  if (req.nextUrl.pathname !== '/' && req.nextUrl.locale === 'und') {
-    return NextResponse.redirect(new URL(`/en${req.nextUrl.pathname}`, req.url))
+  if (pathname !== '/' && locale === 'und') {
+    return NextResponse.redirect(new URL(`/en${pathname}`, url))
+  }
+
+  //Redirect for index page as it's meant to be bilingual so we don't want users navigating to /en or /fr
+  if ((locale === 'en' || locale === 'fr') && pathname === '/') {
+    return NextResponse.redirect(new URL(`/`, url))
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/auto-instrumentations-node": "^0.36.0",
         "@opentelemetry/sdk-node": "^0.35.0",
-        "@reach/auto-id": "^0.18.0",
         "axios": "^1.3.4",
         "babel-plugin-macros": "^3.1.0",
         "cross-env": "^7.0.3",
@@ -5983,27 +5982,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
-    "node_modules/@reach/auto-id": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.18.0.tgz",
-      "integrity": "sha512-XwY1IwhM7mkHZFghhjiqjQ6dstbOdpbFLdggeke75u8/8icT8uEHLbovFUgzKjy9qPvYwZIB87rLiR8WdtOXCg==",
-      "dependencies": {
-        "@reach/utils": "0.18.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/utils": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.18.0.tgz",
-      "integrity": "sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==",
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.5.0",
@@ -24723,20 +24701,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
-    "@reach/auto-id": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.18.0.tgz",
-      "integrity": "sha512-XwY1IwhM7mkHZFghhjiqjQ6dstbOdpbFLdggeke75u8/8icT8uEHLbovFUgzKjy9qPvYwZIB87rLiR8WdtOXCg==",
-      "requires": {
-        "@reach/utils": "0.18.0"
-      }
-    },
-    "@reach/utils": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.18.0.tgz",
-      "integrity": "sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==",
-      "requires": {}
     },
     "@remix-run/router": {
       "version": "1.5.0",

--- a/pages/auth/logout.js
+++ b/pages/auth/logout.js
@@ -26,18 +26,18 @@ Logout.getLayout = function PageLayout(page) {
 }
 
 export async function getServerSideProps({ req, res, locale }) {
-  const logoutURL =
-    !AuthIsDisabled() &&
-    (await getLogoutURL(req).catch((error) => {
-      logger.error(error)
-      res.statusCode = 500
-      throw error
-    }))
+  const logoutURL = !AuthIsDisabled()
+    ? await getLogoutURL(req).catch((error) => {
+        logger.error(error)
+        res.statusCode = 500
+        throw error
+      })
+    : '/'
 
   return {
     props: {
       locale,
-      logoutURL: logoutURL || '/',
+      logoutURL: logoutURL,
     },
   }
 }

--- a/pages/auth/logout.js
+++ b/pages/auth/logout.js
@@ -1,18 +1,12 @@
-import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { getLogoutURL, AuthIsDisabled } from '../../lib/auth'
 import { LoadingSpinner } from '@dts-stn/service-canada-design-system'
 
 export default function Logout(props) {
-  const router = useRouter()
-
   //Redirect to ECAS global sign out
   useEffect(() => {
-    if (!router.isReady) return
-    if (!router.query.error) {
-      router.push(props.logoutURL)
-    }
-  }, [router, props.logoutURL])
+    window.location.replace(`${window.location.origin}${props.logoutURL}`)
+  }, [props.logoutURL])
 
   return (
     <div className="grid h-screen place-items-center">

--- a/pages/auth/logout.js
+++ b/pages/auth/logout.js
@@ -5,7 +5,7 @@ import { LoadingSpinner } from '@dts-stn/service-canada-design-system'
 export default function Logout(props) {
   //Redirect to ECAS global sign out
   useEffect(() => {
-    window.location.replace(`${window.location.origin}${props.logoutURL}`)
+    window.location.replace(props.logoutURL)
   }, [props.logoutURL])
 
   return (


### PR DESCRIPTION
## [ADO-121071](https://dev.azure.com/VP-BD/DECD/_workitems/edit/121071)

### Description
This PR updates the middleware to prevent users from having a selected language on the index page and will redirect them to `/` if they try to navigate there (either manually or via signing out in local dev).

This PR also removes the router instance in `/auth/logout` since it was causing some weird behavior in favor of using `window.location.replace()` instead.

Fixes [AB#121071](https://dev.azure.com/VP-BD/DECD/_workitems/edit/121071)

I've also updated the logoutURL prop to be more fail safe.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/my-dashboard` and select "Sign out" from the menu. You should be redirected back to `/`
4. Repeat step 3 but sign out via the modal
