### PR TITLE
Fouc fix

### DIFF
--- a/components/MetaData.js
+++ b/components/MetaData.js
@@ -7,6 +7,22 @@ export default function MetaData(props) {
   return (
     <>
       <Head>
+        <style jsx>
+          {`
+            html {
+              animation: fouc-fix 0.001s steps(1);
+            }
+            @keyframes fouc-fix {
+              0% {
+                visibility: hidden;
+              }
+              100% {
+                visibility: visible;
+              }
+            }
+          `}
+        </style>
+
         <title>{d.title}</title>
         <meta charSet="utf-8" />
         <meta name="description" content={d.desc} />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,25 +2,9 @@ import '../styles/globals.css'
 import Layout from '../components/Layout'
 import { config } from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'
-import { useEffect } from 'react'
 config.autoAddCss = false
 
 export default function MyApp({ Component, pageProps }) {
-  useEffect(() => {
-    let domReady = (cb) => {
-      document.readyState === 'interactive' ||
-      document.readyState === 'complete'
-        ? cb()
-        : document.addEventListener('DOMContentLoaded', cb)
-    }
-
-    domReady(() => {
-      // Display body when DOM is loaded
-      document.body.style.visibility = 'visible'
-    })
-  }),
-    []
-
   /* istanbul ignore next */
   if (Component.getLayout) {
     return Component.getLayout(<Component {...pageProps} />)

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,9 +2,25 @@ import '../styles/globals.css'
 import Layout from '../components/Layout'
 import { config } from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'
+import { useEffect } from 'react'
 config.autoAddCss = false
 
 export default function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    let domReady = (cb) => {
+      document.readyState === 'interactive' ||
+      document.readyState === 'complete'
+        ? cb()
+        : document.addEventListener('DOMContentLoaded', cb)
+    }
+
+    domReady(() => {
+      // Display body when DOM is loaded
+      document.body.style.visibility = 'visible'
+    })
+  }),
+    []
+
   /* istanbul ignore next */
   if (Component.getLayout) {
     return Component.getLayout(<Component {...pageProps} />)

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,8 +4,8 @@ export default function Document() {
   return (
     <Html>
       <Head />
-      <body>
-        {/* Dummy script that will force the page to render only after CSS is loaded */}
+      <body style={{ visibility: 'hidden' }}>
+        {/* Dummy script that will force the page to render only after CSS is loaded - fix for FireFox only */}
         <script>0</script>
         <Main />
         <NextScript />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,7 +4,7 @@ export default function Document() {
   return (
     <Html>
       <Head />
-      <body style={{ visibility: 'hidden' }}>
+      <body>
         {/* Dummy script that will force the page to render only after CSS is loaded - fix for FireFox only */}
         <script>0</script>
         <Main />


### PR DESCRIPTION
## [ADO-122137](https://dev.azure.com/VP-BD/DECD/_workitems/edit/122137)

### Description
It was discovered that there was still a FOUC(flash of unstyled content) issue happening on browsers aside from FireFox (which was fixed in #247). The fix for FF did not apply to other browsers such as Chrome, Edge, etc, so this PR aims to rectify that. This is done by momentarily setting the visibility of the page to hidden when the page loads and then sets it back to visible once the CSS has loaded, effectively getting rid of the FOUC issue.

I've chosen to do it this way rather than using state management to track when the page is ready from the DOM so that our site will continue to work even if JS is disabled.

Note this issue only shows up in a prod environment, so using `npm run dev` will not show this issue.

### What to test for/How to test
1. Pull in branch
2. Type `npm run build` and `npm run start`
3. Open the application and navigate through the pages on Chrome & Edge (and FF if you want to also confirm the issue doesn't happen there). You should not see any flash of unstyled content when the pages initially load.