### PR TITLE
Update mappers to be in line with new changes

### DIFF
--- a/graphql/mappers/contact-us.js
+++ b/graphql/mappers/contact-us.js
@@ -15,12 +15,14 @@ export async function getContactUsContent() {
   const mappedSecurity = {
     en: {
       breadcrumb:
-        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map((w) => {
-          return {
-            link: w.scPageNameEn,
-            text: w.scTitleEn,
+        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map(
+          (level) => {
+            return {
+              link: level.scPageNameEn,
+              text: level.scTitleEn,
+            }
           }
-        }),
+        ),
       pageName: response.data.schPagev1ByPath.item.scPageNameEn,
       heading: response.data.schPagev1ByPath.item.scTitleEn,
       subHeading: introFragment.scContentEn.json[0].content[0].value,
@@ -59,12 +61,14 @@ export async function getContactUsContent() {
     },
     fr: {
       breadcrumb:
-        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map((w) => {
-          return {
-            link: w.scPageNameFr,
-            text: w.scTitleFr,
+        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map(
+          (level) => {
+            return {
+              link: level.scPageNameFr,
+              text: level.scTitleFr,
+            }
           }
-        }),
+        ),
       pageName: response.data.schPagev1ByPath.item.scPageNameFr,
       heading: response.data.schPagev1ByPath.item.scTitleFr,
       subHeading: introFragment.scContentFr.json[0].content[0].value,

--- a/graphql/mappers/privacy-notice-terms-conditions.js
+++ b/graphql/mappers/privacy-notice-terms-conditions.js
@@ -17,12 +17,14 @@ export async function getPrivacyConditionContent() {
   const mappedPrivacyConditions = {
     en: {
       breadcrumb:
-        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map((w) => {
-          return {
-            link: w.scPageNameEn,
-            text: w.scTitleEn,
+        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map(
+          (level) => {
+            return {
+              link: level.scPageNameEn,
+              text: level.scTitleEn,
+            }
           }
-        }),
+        ),
       pageName: response.data.schPagev1ByPath.item.scPageNameEn,
       heading: response.data.schPagev1ByPath.item.scTitleEn,
       alert: {
@@ -33,12 +35,14 @@ export async function getPrivacyConditionContent() {
     },
     fr: {
       breadcrumb:
-        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map((w) => {
-          return {
-            link: w.scPageNameFr,
-            text: w.scTitleFr,
+        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map(
+          (level) => {
+            return {
+              link: level.scPageNameFr,
+              text: level.scTitleFr,
+            }
           }
-        }),
+        ),
       pageName: response.data.schPagev1ByPath.item.scPageNameFr,
       heading: response.data.schPagev1ByPath.item.scTitleFr,
       alert: {

--- a/graphql/mappers/profile.js
+++ b/graphql/mappers/profile.js
@@ -26,12 +26,14 @@ export async function getProfileContent() {
   const mappedProfile = {
     en: {
       breadcrumb:
-        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map((w) => {
-          return {
-            link: w.scPageNameEn,
-            text: w.scTitleEn,
+        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map(
+          (level) => {
+            return {
+              link: level.scPageNameEn,
+              text: level.scTitleEn,
+            }
           }
-        }),
+        ),
       pageName: response.data.schPagev1ByPath.item.scTitleEn,
       heading: profileIntroFragment.scContentEn.json[0].content[0].value,
       list: response.data.schPagev1ByPath.item.scFragments
@@ -73,12 +75,14 @@ export async function getProfileContent() {
     },
     fr: {
       breadcrumb:
-        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map((w) => {
-          return {
-            link: w.scPageNameFr,
-            text: w.scTitleFr,
+        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map(
+          (level) => {
+            return {
+              link: level.scPageNameFr,
+              text: level.scTitleFr,
+            }
           }
-        }),
+        ),
       pageName: response.data.schPagev1ByPath.item.scTitleFr,
       heading: profileIntroFragment.scContentFr.json[0].content[0].value,
       list: response.data.schPagev1ByPath.item.scFragments

--- a/graphql/mappers/security-settings.js
+++ b/graphql/mappers/security-settings.js
@@ -36,12 +36,14 @@ export async function getSecuritySettingsContent() {
   const mappedSecurity = {
     en: {
       breadcrumb:
-        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map((w) => {
-          return {
-            link: w.scPageNameEn,
-            text: w.scTitleEn,
+        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map(
+          (level) => {
+            return {
+              link: level.scPageNameEn,
+              text: level.scTitleEn,
+            }
           }
-        }),
+        ),
       pageName: response.data.schPagev1ByPath.item.scPageNameEn,
       heading: response.data.schPagev1ByPath.item.scTitleEn,
       subHeading: enContentFragment.json[0].content[0].value,
@@ -75,12 +77,14 @@ export async function getSecuritySettingsContent() {
     },
     fr: {
       breadcrumb:
-        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map((w) => {
-          return {
-            link: w.scPageNameFr,
-            text: w.scTitleFr,
+        response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map(
+          (level) => {
+            return {
+              link: level.scPageNameFr,
+              text: level.scTitleFr,
+            }
           }
-        }),
+        ),
       pageName: response.data.schPagev1ByPath.item.scPageNameFr,
       heading: response.data.schPagev1ByPath.item.scTitleFr,
       subHeading: frContentFragment.json[0].content[0].value,


### PR DESCRIPTION
## [ADO-122407](https://dev.azure.com/VP-BD/DECD/_workitems/edit/122407)

### Description
This small PR serves to follow up the changes made to the dynamic contact pages mapper made in #284. A few of the other mappers were using the old labels for mapping the breadcrumbs, so this PR just updates them to use the new ones.

Fixes [AB#122407](https://dev.azure.com/VP-BD/DECD/_workitems/edit/122407)

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Ensure the application runs as expected