### PR TITLE
Update modal timeout values and added anchors to privacy page

### DIFF
--- a/components/MultiModal.js
+++ b/components/MultiModal.js
@@ -27,8 +27,8 @@ export default function MultiModal(props) {
 
   const { isPrompted, reset, getRemainingTime } = useIdleTimer({
     onIdle: handleOnIdle,
-    promptBeforeIdle: 0.5 * 60 * 1000, // 30 seconds
-    timeout: 1 * 60 * 1000, // 1 minute
+    promptBeforeIdle: 5 * 60 * 1000, // 5 minutes
+    timeout: 15 * 60 * 1000, // 15 minutes
   })
 
   const onStay = () => {

--- a/locales/en.js
+++ b/locales/en.js
@@ -117,12 +117,14 @@ export default {
   footerAboutURL: 'https://www.canada.ca/en/government/about.html',
   footerAbout: 'About Canada.ca',
 
-  footerTermsAndConditionURL: '/privacy-notice-terms-conditions',
+  footerTermsAndConditionURL:
+    '/privacy-notice-terms-conditions#termsAndConditions',
   footerTermsAndCondition: 'Terms and conditions',
+  footerTermsAndConditionAnchor: 'termsAndConditions',
 
-  footerPrivacyURL:
-    'https://srv136.services.gc.ca/ecas-seca/rascl/SCL/TC.aspx?mode=ReadOnly&lang=eng',
+  footerPrivacyURL: '/privacy-notice-terms-conditions',
   footerPrivacy: 'Privacy',
+  footerPrivacyAnchor: 'privacy',
 
   aboutThisSite: 'About this Site',
   topOfPage: 'Top of Page',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -110,12 +110,14 @@ export default {
   footerAboutURL: 'https://www.canada.ca/en/government/about.html',
   footerAbout: 'À propos de Canada.ca',
 
-  footerTermsAndConditionURL: '/fr/avis-confidentialite-modalites/',
+  footerTermsAndConditionURL:
+    '/fr/avis-confidentialite-modalites#termesEtConditions',
   footerTermsAndCondition: 'Avis',
+  footerTermsAndConditionAnchor: 'termesEtConditions',
 
-  footerPrivacyURL:
-    'https://srv136.services.gc.ca/ecas-seca/rascl/SCL/TC.aspx?mode=ReadOnly&lang=fra',
+  footerPrivacyURL: '/fr/avis-confidentialite-modalites/',
   footerPrivacy: 'Confidentialité',
+  footerPrivacyAnchor: 'confidentialité',
 
   aboutThisSite: 'À propos de ce site',
   topOfPage: 'Haut de la page',

--- a/pages/privacy-notice-terms-conditions.js
+++ b/pages/privacy-notice-terms-conditions.js
@@ -18,6 +18,13 @@ import { getAuthModalsContent } from '../graphql/mappers/auth-modals'
 export default function PrivacyCondition(props) {
   const t = props.locale === 'en' ? en : fr
 
+  const pageContent = props.content.content
+  const [privacy, ...termsAndConditions] = pageContent.split(
+    props.locale === 'en'
+      ? /(?=# Terms and conditions of use)/
+      : /(?=# Conditions d’utilisation)/
+  )
+
   return (
     <div className="font-body" data-cy="terms-conditions">
       <Heading
@@ -33,35 +40,68 @@ export default function PrivacyCondition(props) {
         alert_icon_alt_text="info icon"
         alert_icon_id="info-icon"
       />
-      <Markdown
-        options={{
-          overrides: {
-            h1: {
-              props: {
-                className: 'text-3xl font-display font-bold mt-10 mb-3',
+      <section id={t.footerPrivacyAnchor}>
+        <Markdown
+          options={{
+            overrides: {
+              h1: {
+                props: {
+                  className: 'text-3xl font-display font-bold mt-10 mb-3',
+                },
+              },
+              p: {
+                props: {
+                  className: 'mb-3',
+                },
+              },
+              ol: {
+                props: {
+                  className:
+                    'list-[lower-decimal] [&>li>ol]:list-[lower-latin] [&>li>ol>li>ol]:list-[lower-roman] mx-8 mb-3',
+                },
+              },
+              a: {
+                props: {
+                  className: 'underline text-deep-blue-dark cursor-pointer',
+                },
               },
             },
-            p: {
-              props: {
-                className: 'mb-3',
+          }}
+        >
+          {privacy}
+        </Markdown>
+      </section>
+      <section id={t.footerTermsAndConditionAnchor}>
+        <Markdown
+          options={{
+            overrides: {
+              h1: {
+                props: {
+                  className: 'text-3xl font-display font-bold mt-10 mb-3',
+                },
+              },
+              p: {
+                props: {
+                  className: 'mb-3',
+                },
+              },
+              ol: {
+                props: {
+                  className:
+                    'list-[lower-decimal] [&>li>ol]:list-[lower-latin] [&>li>ol>li>ol]:list-[lower-roman] mx-8 mb-3',
+                },
+              },
+              a: {
+                props: {
+                  className: 'underline text-deep-blue-dark cursor-pointer',
+                },
               },
             },
-            ol: {
-              props: {
-                className:
-                  'list-[lower-decimal] [&>li>ol]:list-[lower-latin] [&>li>ol>li>ol]:list-[lower-roman] mx-8 mb-3',
-              },
-            },
-            a: {
-              props: {
-                className: 'underline text-deep-blue-dark cursor-pointer',
-              },
-            },
-          },
-        }}
-      >
-        {props.content.content}
-      </Markdown>
+          }}
+        >
+          {termsAndConditions[0]}
+        </Markdown>
+      </section>
       <BackToButton
         buttonHref={t.url_dashboard}
         buttonId="back-to-dashboard-button"


### PR DESCRIPTION
## [ADO-123258](https://dev.azure.com/VP-BD/DECD/_workitems/edit/123258)

### Description
This PR updates the modal timeout values temporarily until we get more direction. Now, a user will be prompted after 5 minutes of inactivity, and redirected after an additional 15 minutes. This PR also adjusts the privacy link in the footer to link to our internal page. I've split the markdown coming from AEM using a regular expression and have attached anchors to the privacy section and terms and condition section (of which I'm only currently linking to the terms and conditions since linking to the privacy section would put the user part way down the page when that section is already at the top which is bad UX, but I've kept that id there for consistency).

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Scroll down to the bottom of the page and select both links in the footer and confirm you are redirected to the terms and conditions section when selecting that link, and to the top of the page when selecting the other
4. Confirm you are not redirected to the index page after 1 minute and 30 seconds of inactivity like before

### Additional Notes
This is a temporary fix given MSCA should have these 2 pages separate. TBS has been made aware and they have a backlog item created to address this issue.