### PR TITLE
Fix logout functionality

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -6,7 +6,6 @@ import {
 } from '@dts-stn/service-canada-design-system'
 import { useState, cloneElement } from 'react'
 import MetaData from './MetaData'
-import { signOut } from 'next-auth/react'
 import PhaseBanner from './PhaseBanner'
 import en from '../locales/en'
 import fr from '../locales/fr'
@@ -97,9 +96,6 @@ export default function Layout(props) {
           props.children.props.aaPrefix
         }
         menuProps={{
-          onSignOut: () => {
-            signOut()
-          },
           menuList: [
             {
               key: 'dashKey',

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "lodash.throttle": "^4.1.1",
         "markdown-to-jsx": "^7.2.0",
         "next": "^12.3.3",
-        "next-auth": "^4.20.1",
+        "next-auth": "^4.22.1",
         "next-i18next": "^13.0.3",
         "prom-client": "^12.0.0",
         "prop-types": "^15.8.1",
@@ -15898,9 +15898,9 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.20.1",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.20.1.tgz",
-      "integrity": "sha512-ZcTUN4qzzZ/zJYgOW0hMXccpheWtAol8QOMdMts+LYRcsPGsqf2hEityyaKyECQVw1cWInb9dF3wYwI5GZdEmQ==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.22.1.tgz",
+      "integrity": "sha512-NTR3f6W7/AWXKw8GSsgSyQcDW6jkslZLH8AiZa5PQ09w1kR8uHtR9rez/E9gAq/o17+p0JYHE8QjF3RoniiObA==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@panva/hkdf": "^1.0.2",
@@ -32230,9 +32230,9 @@
       }
     },
     "next-auth": {
-      "version": "4.20.1",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.20.1.tgz",
-      "integrity": "sha512-ZcTUN4qzzZ/zJYgOW0hMXccpheWtAol8QOMdMts+LYRcsPGsqf2hEityyaKyECQVw1cWInb9dF3wYwI5GZdEmQ==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.22.1.tgz",
+      "integrity": "sha512-NTR3f6W7/AWXKw8GSsgSyQcDW6jkslZLH8AiZa5PQ09w1kR8uHtR9rez/E9gAq/o17+p0JYHE8QjF3RoniiObA==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "@panva/hkdf": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lodash.throttle": "^4.1.1",
     "markdown-to-jsx": "^7.2.0",
     "next": "^12.3.3",
-    "next-auth": "^4.20.1",
+    "next-auth": "^4.22.1",
     "next-i18next": "^13.0.3",
     "prom-client": "^12.0.0",
     "prop-types": "^15.8.1",

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -70,6 +70,6 @@ export default NextAuth({
     },
   },
   pages: {
-    signIn: '/auth/login',
+    signIn: '/auth/login/',
   },
 })

--- a/pages/auth/logout.js
+++ b/pages/auth/logout.js
@@ -5,7 +5,11 @@ import { LoadingSpinner } from '@dts-stn/service-canada-design-system'
 export default function Logout(props) {
   //Redirect to ECAS global sign out
   useEffect(() => {
-    window.location.replace(props.logoutURL)
+    const logout = async () => {
+      await signOut({ redirect: false })
+      window.location.replace(props.logoutURL)
+    }
+    logout().catch(console.error)
   }, [props.logoutURL])
 
   return (
@@ -31,7 +35,7 @@ export async function getServerSideProps({ req, res, locale }) {
   return {
     props: {
       locale,
-      logoutURL: logoutURL,
+      logoutURL: logoutURL ?? '/',
     },
   }
 }

--- a/pages/auth/logout.js
+++ b/pages/auth/logout.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { getLogoutURL, AuthIsDisabled } from '../../lib/auth'
 import { LoadingSpinner } from '@dts-stn/service-canada-design-system'
+import { signOut } from 'next-auth/react'
 
 export default function Logout(props) {
   //Redirect to ECAS global sign out


### PR DESCRIPTION
## [ADO-118345](https://dev.azure.com/VP-BD/DECD/_workitems/edit/118345)

### Description
This PR removes the `signOut` event call from the DS menu component and implements it asynchronously on the logout page. This was an oversight before as the session would not end if the user were to sign out from the time out modal. This PR also updates `next-auth` to the latest version. 

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev` or `npm run build` and `npm run start`
3. Ensure you are connected to the proxy & go through the login process
4. Once on the dashboard, select sign out from the menu.
5. Confirm that you are first redirected to `/auth/logout` and then to the global sign out page
6. Ensure that the next auth session token has been wiped from your session storage (if this has been done, you should be prompted to go through the login flow again once you select a language).