### PR TITLE
128802 language neutral aa tagging

### DIFF
--- a/components/BackToButton.js
+++ b/components/BackToButton.js
@@ -9,7 +9,7 @@ export default function BackToButton(props) {
           <a
             id={props.buttonId}
             className="inline-block my-4 py-2.5 px-3.5 font-display text-xl rounded bg-gray-30a text-deep-blue-60b hover:bg-gray-50a hover:cursor-pointer focus:ring focus:ring-offset-4 ring-deep-blue-60f"
-            data-gc-analytics-customclick={`${props.refPageAA}:${props.buttonLinkText}`}
+            data-gc-analytics-customclick={`${props.refPageAA}:${props.id}`}
           >
             {props.buttonLinkText}
           </a>

--- a/components/BenefitTasks.js
+++ b/components/BenefitTasks.js
@@ -47,7 +47,7 @@ export default function BenefitTasks(props) {
                       props.openModal(task.link, 'betaModal')
                     }
                   }}
-                  data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:${task.title}`}
+                  data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:${task.id}`}
                   className="flex items-center underline py-1 text-deep-blue-dark hover:text-blue-hover"
                 >
                   <FontAwesomeIcon

--- a/components/ExitBeta.js
+++ b/components/ExitBeta.js
@@ -23,7 +23,7 @@ export default function ExitBeta(props) {
           type="button"
           aria-label={props.closeModalAria}
           onClick={props.closeModal}
-          data-gc-analytics-customclick={`ESDC-EDSC:${props.refPageAA}:Close-Fermer`}
+          data-gc-analytics-customclick={`ESDC-EDSC:${props.refPageAA}:Close`}
         >
           <FontAwesomeIcon aria-hidden="true" icon={solid('xmark')} size="xl" />
         </button>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -60,9 +60,7 @@ export default function Layout(props) {
           bannerLinkHref={props.bannerContent.bannerLinkHref || ''}
           bannerButtonText={props.bannerContent.bannerButtonText || ''}
           bannerButtonLink={props.bannerContent.bannerButtonLink || ''}
-          bannerButtonExternalText={
-            props.bannerContent.bannerButtonExternalText || ''
-          }
+          id={props.bannerContent.id || ''}
           bannerButtonExternalLink
           icon={props.bannerContent.icon || ''}
           popupContent={props.popupContent || ''}
@@ -99,6 +97,7 @@ export default function Layout(props) {
           menuList: [
             {
               key: 'dashKey',
+              id: 'dash',
               value: t.menuItems.dashboard,
               path: `${
                 props.locale === 'en'
@@ -109,12 +108,14 @@ export default function Layout(props) {
             },
             {
               key: 'profileKey',
+              id: 'profile',
               value: t.menuItems.profile,
               path: `${props.locale === 'en' ? '/en/profile' : '/fr/profil'}`,
               component: Link,
             },
             {
               key: 'securityKey',
+              id: 'security',
               value: t.menuItems.security,
               path: `${
                 props.locale === 'en'
@@ -125,6 +126,7 @@ export default function Layout(props) {
             },
             {
               key: 'contactKey',
+              id: 'contact',
               value: t.menuItems.contactUs,
               path: `${
                 props.locale === 'en' ? '/en/contact-us' : '/fr/contactez-nous'
@@ -133,6 +135,7 @@ export default function Layout(props) {
             },
             {
               key: 'signOutKey',
+              id: 'signOut',
               value: t.menuItems.signOut,
               path: '/auth/logout',
               component: Link,

--- a/components/MostReqTasks.js
+++ b/components/MostReqTasks.js
@@ -24,7 +24,7 @@ export default function MostReqTasks(props) {
                       props.openModal(task.link, 'betaModal')
                     }
                   }}
-                  data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:${task.title}`}
+                  data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:${task.id}`}
                   className="flex items-center underline pl-2 text-white hover:text-gray-50a"
                 >
                   <FontAwesomeIcon

--- a/components/PageLink.js
+++ b/components/PageLink.js
@@ -21,7 +21,7 @@ export default function PageLink(props) {
             <a
               id={`link-for-${linkID}`}
               data-cy={props.dataCy}
-              data-gc-analytics-customclick={`${props.refPageAA}:${props.linkID}`}
+              data-gc-analytics-customclick={`${props.refPageAA}:${props.linkId}`}
               className="text-blue-default hover:text-blue-hover visited:text-purple-medium underline"
             >
               {props.linkText}
@@ -35,6 +35,7 @@ export default function PageLink(props) {
           buttonId={props.buttonId}
           buttonLinkText={props.buttonLinkText}
           refPageAA={props.refPageAA}
+          id={props.dashId}
         />
       </div>
     </>

--- a/components/PageLink.js
+++ b/components/PageLink.js
@@ -21,7 +21,7 @@ export default function PageLink(props) {
             <a
               id={`link-for-${linkID}`}
               data-cy={props.dataCy}
-              data-gc-analytics-customclick={`${props.refPageAA}:${props.linkText}`}
+              data-gc-analytics-customclick={`${props.refPageAA}:${props.linkID}`}
               className="text-blue-default hover:text-blue-hover visited:text-purple-medium underline"
             >
               {props.linkText}

--- a/components/PhaseBanner.js
+++ b/components/PhaseBanner.js
@@ -31,7 +31,7 @@ export default function PhaseBanner(props) {
             rel={
               props.bannerButtonExternalLink ? 'noopener noreferrer' : undefined
             }
-            data-gc-analytics-customclick={`ESDC-EDSC:${props.refPageAA}:${props.bannerButtonExternalText}`}
+            data-gc-analytics-customclick={`ESDC-EDSC:${props.refPageAA}:${props.id}`}
           >
             <span className="mr-2 underline">{props.bannerLink}</span>
             {props.bannerButtonExternalLink && (

--- a/components/ProfileTasks.js
+++ b/components/ProfileTasks.js
@@ -25,7 +25,7 @@ export default function ProfileTasks(props) {
                       props.openModal(task.link, 'betaModal')
                     }
                   }}
-                  data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:${task.title}`}
+                  data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:${task.id}`}
                 >
                   <FontAwesomeIcon
                     icon={

--- a/components/ViewMoreLessButton.js
+++ b/components/ViewMoreLessButton.js
@@ -21,13 +21,13 @@ export default function ViewMoreLessButton(props) {
           <FontAwesomeIcon
             icon={solid('circle-chevron-up')}
             className={`text-46px pr-3`}
-            data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:Contract-Diminuer`}
+            data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:Contract`}
           />
         ) : (
           <FontAwesomeIcon
             icon={solid('circle-chevron-down')}
             className={`text-46px pr-3`}
-            data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:Expand-Etendre`}
+            data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:Expand`}
           />
         )}
         <span className="text-left underline font-body">{props.caption}</span>

--- a/graphql/mappers/beta-banner-opt-out.js
+++ b/graphql/mappers/beta-banner-opt-out.js
@@ -26,6 +26,7 @@ export async function getBetaBannerContent() {
           resOptOutContent.scFragments[1].scDestinationURLEn
         ) || '/',
       icon: resOptOutContent.scFragments[0].scIconCSS,
+      id: resOptOutContent.scFragments[0].scId,
     },
     fr: {
       bannerBoldText: resOptOutContent.scContentFr.json[0].content[0].value,
@@ -42,6 +43,7 @@ export async function getBetaBannerContent() {
           resOptOutContent.scFragments[1].scDestinationURLEn
         ) || '/',
       icon: resOptOutContent.scFragments[0].scIconCSS,
+      id: resOptOutContent.scFragments[0].scId,
     },
   }
 

--- a/graphql/mappers/my-dashboard.js
+++ b/graphql/mappers/my-dashboard.js
@@ -22,6 +22,7 @@ export async function getMyDashboardContent() {
                 title: list.scTitleEn,
                 tasks: list.scItems.map((item) => {
                   return {
+                    id: item.scId,
                     title: item.scLinkTextEn,
                     areaLabel: item.scLinkTextAssistiveEn,
                     link: buildLink(item.schURLType, item.scDestinationURLEn),
@@ -59,6 +60,7 @@ export async function getMyDashboardContent() {
                 title: list.scTitleFr,
                 tasks: list.scItems.map((item) => {
                   return {
+                    id: item.scId,
                     title: item.scLinkTextFr,
                     areaLabel: item.scLinkTextAssistiveFr,
                     link: buildLink(item.schURLType, item.scDestinationURLFr),

--- a/graphql/mappers/privacy-notice-terms-conditions.js
+++ b/graphql/mappers/privacy-notice-terms-conditions.js
@@ -16,6 +16,7 @@ export async function getPrivacyConditionContent() {
 
   const mappedPrivacyConditions = {
     en: {
+      id: response.data.schPagev1ByPath.item.scId,
       breadcrumb:
         response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map(
           (level) => {
@@ -34,6 +35,7 @@ export async function getPrivacyConditionContent() {
       content: privacyTermsConditionsFragment.scContentEn.markdown,
     },
     fr: {
+      id: response.data.schPagev1ByPath.item.scId,
       breadcrumb:
         response.data.schPagev1ByPath.item.scBreadcrumbParentPages.map(
           (level) => {

--- a/graphql/mappers/privacy-notice-terms-conditions.js
+++ b/graphql/mappers/privacy-notice-terms-conditions.js
@@ -23,6 +23,7 @@ export async function getPrivacyConditionContent() {
             return {
               link: level.scPageNameEn,
               text: level.scTitleEn,
+              id: level.scId,
             }
           }
         ),
@@ -42,6 +43,7 @@ export async function getPrivacyConditionContent() {
             return {
               link: level.scPageNameFr,
               text: level.scTitleFr,
+              id: level.scId,
             }
           }
         ),

--- a/graphql/mappers/profile.js
+++ b/graphql/mappers/profile.js
@@ -44,6 +44,7 @@ export async function getProfileContent() {
             element.scId === 'oas-profile-list'
           ) {
             return {
+              id: element.scId,
               title: element.scTitleEn,
               tasks: element.scItems.map((item) => {
                 return {
@@ -93,6 +94,7 @@ export async function getProfileContent() {
             element.scId === 'oas-profile-list'
           ) {
             return {
+              id: element.scId,
               title: element.scTitleFr,
               tasks: element.scItems.map((item) => {
                 return {

--- a/graphql/mappers/profile.js
+++ b/graphql/mappers/profile.js
@@ -67,6 +67,7 @@ export async function getProfileContent() {
           enLookingForFragment.json[1].content[1].value,
         ],
         link: 'security-settings',
+        id: 'security-settings',
       },
       backToDashboard: {
         id: backToDashboardFragment.scId,
@@ -117,6 +118,7 @@ export async function getProfileContent() {
           frLookingForFragment.json[1].content[1].value,
         ],
         link: 'parametres-securite',
+        id: 'security-settings',
       },
       backToDashboard: {
         id: backToDashboardFragment.scId,

--- a/graphql/mappers/security-settings.js
+++ b/graphql/mappers/security-settings.js
@@ -53,6 +53,7 @@ export async function getSecuritySettingsContent() {
           return element.value || null
         }),
         link: '/profile',
+        id: 'profile',
       },
       securityQuestions: {
         linkTitle: {
@@ -94,6 +95,7 @@ export async function getSecuritySettingsContent() {
           return element.value || null
         }),
         link: '/fr/profil',
+        id: 'profile',
       },
       securityQuestions: {
         linkTitle: {

--- a/graphql/queries/my-dashboard.graphql
+++ b/graphql/queries/my-dashboard.graphql
@@ -47,6 +47,7 @@
                                     scTitleFr
                                     scItems {
                                         ... on SCHTaskv1Model{
+                                            scId
                                             scLinkTextEn
                                             scLinkTextFr
                                             scLinkTextAssistiveEn

--- a/locales/en.js
+++ b/locales/en.js
@@ -138,6 +138,7 @@ export default {
   url_serviceCanada:
     'https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html',
   url_dashboard: '/my-dashboard',
+  id_dashboard: 'my-dashboard',
   aria_exit_beta_modal: 'Exiting beta warning modal',
   close_modal: 'Close modal',
 }

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -131,6 +131,7 @@ export default {
   url_serviceCanada:
     'https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html',
   url_dashboard: '/fr/mon-tableau-de-bord',
+  id_dashboard: 'my-dashboard',
   aria_exit_beta_modal: 'Exiting beta warning modal',
   close_modal: 'Fermer modal',
 }

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -35,7 +35,7 @@ export default function MyDashboard(props) {
       window.removeEventListener('click', throttledOnClickEvent)
     }
   }, [throttledOnClickEvent])
-  console.log(props.content, 'kkkkkkkkkkkk')
+
   return (
     <div id="myDashboardContent" data-testid="myDashboardContent-test">
       <Heading id="my-dashboard-heading" title={props.content.heading} />

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -35,7 +35,7 @@ export default function MyDashboard(props) {
       window.removeEventListener('click', throttledOnClickEvent)
     }
   }, [throttledOnClickEvent])
-
+  console.log(props.content, 'kkkkkkkkkkkk')
   return (
     <div id="myDashboardContent" data-testid="myDashboardContent-test">
       <Heading id="my-dashboard-heading" title={props.content.heading} />
@@ -68,7 +68,7 @@ export default function MyDashboard(props) {
             >
               {tasks.map((taskList, index) => {
                 return (
-                  <div className="" key={index} data-cy="Task">
+                  <div key={index} data-cy="Task">
                     <BenefitTasks
                       acronym={acronym(card.title)}
                       taskList={taskList}

--- a/pages/privacy-notice-terms-conditions.js
+++ b/pages/privacy-notice-terms-conditions.js
@@ -107,7 +107,7 @@ export default function PrivacyCondition(props) {
         buttonId="back-to-dashboard-button"
         buttonLinkText={t.backToDashboard}
         refPageAA={props.aaPrefix}
-        id={t.id}
+        id={t.id_dashboard}
       />
       <Date id="termsConditionsDateModified" date="20230331" />
     </div>

--- a/pages/privacy-notice-terms-conditions.js
+++ b/pages/privacy-notice-terms-conditions.js
@@ -107,6 +107,7 @@ export default function PrivacyCondition(props) {
         buttonId="back-to-dashboard-button"
         buttonLinkText={t.backToDashboard}
         refPageAA={props.aaPrefix}
+        id={t.id}
       />
       <Date id="termsConditionsDateModified" date="20230331" />
     </div>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -33,7 +33,7 @@ export default function Profile(props) {
       window.removeEventListener('click', throttledOnClickEvent)
     }
   }, [throttledOnClickEvent])
-  console.log(props.content.backToDashboard, '00000000000000')
+
   return (
     <div id="homeContent" data-testid="profileContent-test">
       <Heading id="my-dashboard-heading" title={props.content.pageName} />
@@ -63,6 +63,8 @@ export default function Profile(props) {
         buttonId="back-to-dashboard-button"
         buttonLinkText={props.content.backToDashboard.btnText}
         refPageAA={props.aaPrefix}
+        dashId={t.id_dashboard}
+        linkId={props.content.lookingFor.id}
       ></PageLink>
     </div>
   )
@@ -149,7 +151,7 @@ export async function getServerSideProps({ res, locale }) {
       bannerContent: locale === 'en' ? bannerContent.en : bannerContent.fr,
       popupContent: locale === 'en' ? popupContent.en : popupContent.fr,
       popupContentNA: locale === 'en' ? popupContentNA.en : popupContentNA.fr,
-      aaPrefix: `ESDC-EDSC:${content.en?.heading || content.en?.title}`,
+      aaPrefix: `ESDC-EDSC:${content.en?.pageName}`,
       popupStaySignedIn:
         locale === 'en'
           ? authModals.mappedPopupStaySignedIn.en

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -33,7 +33,7 @@ export default function Profile(props) {
       window.removeEventListener('click', throttledOnClickEvent)
     }
   }, [throttledOnClickEvent])
-
+  console.log(props.content.backToDashboard, '00000000000000')
   return (
     <div id="homeContent" data-testid="profileContent-test">
       <Heading id="my-dashboard-heading" title={props.content.pageName} />
@@ -57,7 +57,7 @@ export default function Profile(props) {
         accessText={props.content.lookingFor.subText[0]}
         linkText={props.content.lookingFor.subText[1]}
         href={props.content.lookingFor.link}
-        linkID="link-id"
+        linkID={props.content.backToDashboard.id}
         dataCy="access-security-page-link"
         buttonHref={props.content.backToDashboard.btnLink}
         buttonId="back-to-dashboard-button"

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -58,7 +58,7 @@ export default function SecuritySettings(props) {
         accessText={props.content.lookingFor.subText[0]}
         linkText={props.content.lookingFor.subText[1]}
         href={props.content.lookingFor.link}
-        linkID="link-id"
+        linkID={t.backToDashboard.id}
         dataCy="access-profile-page-link"
         buttonHref={t.url_dashboard}
         buttonId="back-to-dashboard-button"

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -29,7 +29,6 @@ export default function SecuritySettings(props) {
       window.removeEventListener('click', throttledOnClickEvent)
     }
   }, [throttledOnClickEvent])
-
   return (
     <div id="securityContent" data-testid="securityContent-test">
       <Heading id="my-dashboard-heading" title={props.content.heading} />
@@ -64,6 +63,8 @@ export default function SecuritySettings(props) {
         buttonId="back-to-dashboard-button"
         buttonLinkText={t.backToDashboard}
         refPageAA={props.aaPrefix}
+        dashId={t.id_dashboard}
+        linkId={props.content.lookingFor.id}
       ></PageLink>
     </div>
   )


### PR DESCRIPTION
## [ADO-128802](https://dev.azure.com/VP-BD/DECD/_workitems/edit/128802)

### Description

List of proposed changes:

- Enable language-neutral tracking for AA
-

### What to test for/How to test

Inspect every AA-tracked link on each page in the browser console. (Identified by data-gc-analytics-customclick prop) They should be identical in the French and English versions of the page. 

### Additional Notes

Language-neutral tracking will be broken on components that rely on DS for the AA tag. 