### PR TITLE
Wrap continue button in form instead of anchor

### DIFF
--- a/components/ExitBeta.js
+++ b/components/ExitBeta.js
@@ -39,15 +39,15 @@ export default function ExitBeta(props) {
           onClick={props.closeModal}
           text={props.popupSecondaryBtn.text}
         />
-        {/* Using anchor tag due to ref errors
-        continueLink is always external so NextJS routing can be ignored */}
-        <a
-          href={props.continueLink}
-          id={props.popupPrimaryBtn.id}
-          className="flex justify-center align-middle text-lg py-2 px-4 mt-6 bg-deep-blue-medium text-white font-body rounded focus:ring-offset-4 focus:ring-4 focus:ring-deep-blue-focus focus:bg-deep-blue-focus hover:bg-deep-blue-light md:mt-auto"
-        >
-          {props.popupPrimaryBtn.text}
-        </a>
+        <form action={props.continueLink}>
+          <Button
+            className="w-full block mt-6 md:mt-0 md:w-fit bg-blue-primary"
+            id={props.popupPrimaryBtn.id}
+            styling="primary"
+            text={props.popupPrimaryBtn.text}
+            type="submit"
+          />
+        </form>
       </div>
     </div>
   )

--- a/next.config.js
+++ b/next.config.js
@@ -74,7 +74,7 @@ const securityHeaders = [
   {
     key: 'Content-Security-Policy',
     value:
-      "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; form-action 'self' https://srv113-i.lab.hrdc-drhc.gc.ca; object-src 'none'; script-src-elem 'self' 'unsafe-inline' https://assets.adobedtm.com; script-src 'self' 'unsafe-eval' https://assets.adobedtm.com; connect-src 'self' https://canada.demdex.net https://dpm.demdex.net https://assets.adobedtm.com https://srv241-s2.lab.hrdc-drhc.gc.ca; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; frame-src 'self' 'unsafe-inline' https://assets.adobedtm.com; img-src 'self' data: https:",
+      "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; form-action 'self' https://srv113-i.lab.hrdc-drhc.gc.ca https://srv241-s2.sade.hrdc-drhc.gc.ca; object-src 'none'; script-src-elem 'self' 'unsafe-inline' https://assets.adobedtm.com; script-src 'self' 'unsafe-eval' https://assets.adobedtm.com; connect-src 'self' https://canada.demdex.net https://dpm.demdex.net https://assets.adobedtm.com https://srv241-s2.lab.hrdc-drhc.gc.ca; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; frame-src 'self' 'unsafe-inline' https://assets.adobedtm.com; img-src 'self' data: https:",
   },
 ]
 


### PR DESCRIPTION
## [ADO-129454](https://dev.azure.com/VP-BD/DECD/_workitems/edit/129454)

### Description
This PR fixes an a11y issue where a button was wrapped in an anchor tag. This causes an issues for screen reader users since it will announce the anchor tag first in focus order and then the button. Placing the button in a form instead and setting the action to the URL fixes this issue. The caveat is that as soon as we set the button type to anything (in this case submit), Tailwind's preflight styling sets the background for buttons with a set type to transparent. Explicitly setting the background color again fixes this issue.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to dashboard and click any of the links, which will open the exit beta prompt. Ensure it links to another page as expected (won't actually load if not authenticated but should redirect regardless)