### PR TITLE
Update Card component to not use underline styling

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -7,7 +7,7 @@ export default function Card(props) {
 
   return (
     <div className="border rounded border-gray-300 shadow my-6" data-cy="cards">
-      <h2 className="py-4 md:py-9 md:mt-2 px-3 sm:px-8 md:px-15 text-4xl font-display font-bold">
+      <h2 className="py-4 md:py-8 md:mt-2 px-3 sm:px-8 md:px-15 text-4xl font-display font-bold">
         {props.cardTitle}
       </h2>
       <ViewMoreLessButton
@@ -21,7 +21,7 @@ export default function Card(props) {
         ariaExpanded={isOpen.toString()}
         icon={isOpen}
         caption={props.viewMoreLessCaption}
-        className="pb-6 md:pb-12 md:pt-0.5 px-3 sm:px-8 md:px-15"
+        className="pb-6 md:pb-8 md:pt-4 px-3 sm:px-8 md:px-15 w-full"
         acronym={props.acronym}
         refPageAA={props.refPageAA}
         ariaLabel={props.cardTitle}

--- a/components/ViewMoreLessButton.js
+++ b/components/ViewMoreLessButton.js
@@ -6,7 +6,7 @@ export default function ViewMoreLessButton(props) {
   return (
     <button
       className={
-        'text-xl leading-8 text-deep-blue-60d hover:text-blue-hover ' +
+        'text-xl leading-8 text-deep-blue-60d hover:text-blue-hover focus:text-blue-hover ' +
         props.className
       }
       data-cy={props.dataCy}
@@ -30,7 +30,7 @@ export default function ViewMoreLessButton(props) {
             data-gc-analytics-customclick={`${props.refPageAA} ${props.acronym}:Expand`}
           />
         )}
-        <span className="text-left underline font-body">{props.caption}</span>
+        <span className="text-left font-body">{props.caption}</span>
       </div>
     </button>
   )


### PR DESCRIPTION
## [ADO-129456](https://dev.azure.com/VP-BD/DECD/_workitems/edit/129456)

### Description
This PR addresses one of the suggestions made on our a11y audit. Note that this is a **usability** issue and not an accessibility issue. I've removed the underline styling from the collapsible card component as that styling is reserved for links and can be confusing to users. In addition, I found while testing that the focus for the `ViewMoreLessButton` component wasn't spanning the entirety of the parent component, which looked really bad. I updated the padding a bit and add the `w-full` class so the focus spans the entirety of the parent now. I've also added focus styling since we only had hover styling.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to the dashboard and tab through the cards, ensuring the focus spans the whole card width and that there is no underline sytling
