### PR TITLE
Update privacy page heading heirarchy

### DIFF
--- a/pages/privacy-notice-terms-conditions.js
+++ b/pages/privacy-notice-terms-conditions.js
@@ -21,8 +21,8 @@ export default function PrivacyCondition(props) {
   const pageContent = props.content.content
   const [privacy, ...termsAndConditions] = pageContent.split(
     props.locale === 'en'
-      ? /(?=# Terms and conditions of use)/
-      : /(?=# Conditions d’utilisation)/
+      ? /(?=## Terms and conditions of use)/
+      : /(?=## Conditions d’utilisation)/
   )
 
   return (
@@ -44,7 +44,7 @@ export default function PrivacyCondition(props) {
         <Markdown
           options={{
             overrides: {
-              h1: {
+              h2: {
                 props: {
                   className: 'text-3xl font-display font-bold mt-10 mb-3',
                 },
@@ -75,7 +75,7 @@ export default function PrivacyCondition(props) {
         <Markdown
           options={{
             overrides: {
-              h1: {
+              h2: {
                 props: {
                   className: 'text-3xl font-display font-bold mt-10 mb-3',
                 },


### PR DESCRIPTION
## [ADO-129453](https://dev.azure.com/VP-BD/DECD/_workitems/edit/129453)

### Description
This PR fixes an accessibility issue with our privacy page. All of our section headings were H1s, which is not allowed as there should only ever be one H1 on a page. An update has been made in AEM to change the section headings to H2s, this PR updates the Markdown styling to target the H2s instead of H1s. 

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to the privacy page, inspect the heading elements and ensure only the very top one is an H1 and the rest are H2s
