### PR TITLE
Update package lock to fix build error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4688,6 +4688,17 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.40.0.tgz",
+      "integrity": "sha512-8WRuvGnfnbeR9ifGjLN8kklk2fkd0gBT6aN7NHO9zeYF/6qacAViD3bwAKqGXKnJgl39l1EU41I9diqUjamEEQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
       "version": "0.37.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.37.1.tgz",
@@ -4904,6 +4915,25 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.40.0.tgz",
+      "integrity": "sha512-YrJgVVAsJHibENSbYmC1x+5jAmkAGZ9yrgmHxc6IyqM3D1mryhqBvMRDD31JoavPYelkS7dmrXWM8g7swX0B+g==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.40.0",
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/sdk-logs": "0.40.0",
+        "@opentelemetry/sdk-metrics": "1.14.0",
+        "@opentelemetry/sdk-trace-base": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/propagator-b3": {
@@ -6070,6 +6100,59 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.40.0.tgz",
+      "integrity": "sha512-/JG7DOLo/Y3VR9azPXlXNRGQff3gp7nQbWl5cFD2SmlYqUrzMq1OjbksZLVztDu1+ynbFunseUG11SxhoxvSRg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.5.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
@@ -24526,6 +24609,14 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
     },
+    "@opentelemetry/api-logs": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.40.0.tgz",
+      "integrity": "sha512-8WRuvGnfnbeR9ifGjLN8kklk2fkd0gBT6aN7NHO9zeYF/6qacAViD3bwAKqGXKnJgl39l1EU41I9diqUjamEEQ==",
+      "requires": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
     "@opentelemetry/auto-instrumentations-node": {
       "version": "0.37.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.37.1.tgz",
@@ -24677,6 +24768,19 @@
             "@opentelemetry/core": "1.14.0",
             "@opentelemetry/otlp-exporter-base": "0.40.0",
             "protobufjs": "^7.1.2"
+          }
+        },
+        "@opentelemetry/otlp-transformer": {
+          "version": "0.40.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.40.0.tgz",
+          "integrity": "sha512-YrJgVVAsJHibENSbYmC1x+5jAmkAGZ9yrgmHxc6IyqM3D1mryhqBvMRDD31JoavPYelkS7dmrXWM8g7swX0B+g==",
+          "requires": {
+            "@opentelemetry/api-logs": "0.40.0",
+            "@opentelemetry/core": "1.14.0",
+            "@opentelemetry/resources": "1.14.0",
+            "@opentelemetry/sdk-logs": "0.40.0",
+            "@opentelemetry/sdk-metrics": "1.14.0",
+            "@opentelemetry/sdk-trace-base": "1.14.0"
           }
         },
         "@opentelemetry/propagator-b3": {
@@ -25419,6 +25523,39 @@
         "@opentelemetry/core": "1.15.0",
         "@opentelemetry/semantic-conventions": "1.15.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@opentelemetry/sdk-logs": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.40.0.tgz",
+      "integrity": "sha512-/JG7DOLo/Y3VR9azPXlXNRGQff3gp7nQbWl5cFD2SmlYqUrzMq1OjbksZLVztDu1+ynbFunseUG11SxhoxvSRg==",
+      "requires": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+          "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.14.0"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+          "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+          "requires": {
+            "@opentelemetry/core": "1.14.0",
+            "@opentelemetry/semantic-conventions": "1.14.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+          "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug=="
+        }
       }
     },
     "@opentelemetry/sdk-metrics": {


### PR DESCRIPTION
### Description
Something happened on #325 when updating from dev that caused some necessary lines in our package lock to be nuked. Our dockerfile runs `npm ci` which fails and makes our TC build fail because of this. This PR just runs `npm i` to update the lock file to be in line with our `package.json`

### What to test for/How to test
1. Pull in branch
2. Type `npm i`
3. Type `npm run dev`
4. Ensure everything works
