### PR TITLE
updated the logout e2e tests

### DIFF
--- a/cypress/e2e/ContactUs.cy.js
+++ b/cypress/e2e/ContactUs.cy.js
@@ -8,12 +8,11 @@ beforeEach(() => {
   cy.visit('/contact-us')
 })
 
-it('Contact us has no detectable a11y violations on load', () => {
-  cy.injectAxe()
-  cy.checkA11y()
-})
-
 describe('Validate Contact Us Landing page', () => {
+  it('Contact us has no detectable a11y violations on load', () => {
+    cy.injectAxe()
+    cy.checkA11y()
+  })
   it('Validate Contact us URL and header in EN and FR', () => {
     contactUsPo.ValidateContactUsUrl()
     contactUsPo.ValidateContactUsHeaderEN()

--- a/cypress/e2e/ContactUsCPP.cy.js
+++ b/cypress/e2e/ContactUsCPP.cy.js
@@ -8,12 +8,11 @@ beforeEach(() => {
   cy.visit('/contact-us/contact-canada-pension-plan')
 })
 
-it('Contact us CPP has no detectable a11y violations on load', () => {
-  cy.injectAxe()
-  cy.checkA11y()
-})
-
 describe('Validate CPP Contact Us Landing page', () => {
+  it('Contact us CPP has no detectable a11y violations on load', () => {
+    cy.injectAxe()
+    cy.checkA11y()
+  })
   it('Validate CPP Contact us URL and header in EN', () => {
     CPPcontactUs.ValidateCPPContactUsUrl()
     CPPcontactUs.ValidateCPPContactUsHeaderEN()

--- a/cypress/e2e/ContactUsEI.cy.js
+++ b/cypress/e2e/ContactUsEI.cy.js
@@ -9,12 +9,11 @@ beforeEach(() => {
   cy.visit('/contact-us/contact-employment-insurance')
 })
 
-it('Contact us EI has no detectable a11y violations on load', () => {
-  cy.injectAxe()
-  cy.checkA11y()
-})
-
 describe('Validate EI Contact Us Landing page', () => {
+  it('Contact us EI has no detectable a11y violations on load', () => {
+    cy.injectAxe()
+    cy.checkA11y()
+  })
   it('Validate EI Contact us URL and header in EN', () => {
     EIcontactUs.ValidateEIContactUsUrl()
     EIcontactUs.ValidateEIContactUsHeaderEN()

--- a/cypress/e2e/ContactUsOAS.cy.js
+++ b/cypress/e2e/ContactUsOAS.cy.js
@@ -9,12 +9,11 @@ beforeEach(() => {
   cy.visit('/contact-us/contact-old-age-security')
 })
 
-it('Contact us OAS has no detectable a11y violations on load', () => {
-  cy.injectAxe()
-  cy.checkA11y()
-})
-
 describe('Validate OAS Contact Us Landing page', () => {
+  it('Contact us OAS has no detectable a11y violations on load', () => {
+    cy.injectAxe()
+    cy.checkA11y()
+  })
   it('Validate OAS Contact us URL and header in EN', () => {
     OAScontactUs.ValidateOASContactUsUrl()
     OAScontactUs.ValidateOASContactUsHeaderEN()

--- a/cypress/e2e/Login.cy.js
+++ b/cypress/e2e/Login.cy.js
@@ -3,11 +3,11 @@ It does not test the authentication functionality currently since those endpoint
 
 beforeEach(() => {
   cy.visit('/auth/login')
-  cy.injectAxe()
 })
 
 describe('Validate login page', () => {
   it('Login has no detectable a11y violations on load', () => {
+    cy.injectAxe()
     cy.checkA11y()
   })
   it('Lands on login page and displays loading spinner', () => {

--- a/cypress/e2e/Login.cy.js
+++ b/cypress/e2e/Login.cy.js
@@ -3,14 +3,13 @@ It does not test the authentication functionality currently since those endpoint
 
 beforeEach(() => {
   cy.visit('/auth/login')
-})
-
-it('Login has no detectable a11y violations on load', () => {
   cy.injectAxe()
-  cy.checkA11y()
 })
 
 describe('Validate login page', () => {
+  it('Login has no detectable a11y violations on load', () => {
+    cy.checkA11y()
+  })
   it('Lands on login page and displays loading spinner', () => {
     cy.get('[data-cy="loading-spinner"]')
       .should('be.visible')

--- a/cypress/e2e/Logout.cy.js
+++ b/cypress/e2e/Logout.cy.js
@@ -2,22 +2,52 @@
 It does not test the authentication functionality currently since those endpoints are on prem only at this time. **/
 
 beforeEach(() => {
-  cy.visit('/auth/logout')
+  cy.visit('/my-dashboard')
 })
 
-it('Logout has no detectable a11y violations on load', () => {
-  cy.injectAxe()
-  cy.checkA11y()
-})
+describe('Validate logout scenario and page', () => {
+  it('should click Sign-out from the menu item go to /auth/logout/', () => {
+    cy.visit('/auth/logout')
+    cy.intercept('POST', 'api/auth/signout').as('signout')
 
-describe('Validate logout page', () => {
-  it('Lands on logout page and displays loading spinner', () => {
+    cy.visit('/my-dashboard')
+    cy.get('[data-testid="menuButton"]').click()
+    cy.get('[id="dropdownNavbar"]>div:nth-child(5)').click()
+
+    cy.wait('@signout')
+      .its('response')
+      .then((response) => {
+        const { statusCode } = response
+        // confirm the status code is 308 for a redirect
+        expect(statusCode).to.eq(308)
+      })
+    cy.url().should('eq', 'http://localhost:3000/en/auth/logout/')
+  })
+
+  it('should show the loading spinner + text the return to index page once logged out', () => {
+    // Create a Promise and capture a reference to its resolve
+    // function so that we can resolve it when we want to:
+    let sendResponse
+    const trigger = new Promise((resolve) => {
+      sendResponse = resolve
+    })
+    // Intercept requests to the URL and does not let the response occur until the Promise is resolved
+    cy.intercept('POST', 'api/auth/signout', async (request) => {
+      await trigger
+      request.reply()
+    })
+    cy.visit('/auth/logout/')
+    // Verify the loading spinner and text
     cy.get('[data-cy="loading-spinner"]')
       .should('be.visible')
       .and('have.text', 'Loading / Chargement en cours ...')
-  })
-  it('Redirects to index page', () => {
-    cy.wait(2000)
-    cy.url().should('contains', '/')
+      .then(() => {
+        // all the resolve function of the above Promise
+        sendResponse()
+        // Assert that the loading spinner is removed from the DOM
+        cy.get('[data-cy="loading-spinner"]').should('not.exist')
+        // Return to index page (this may change as noted at top)
+        cy.url().should('eq', 'http://localhost:3000/')
+      })
   })
 })

--- a/cypress/e2e/Logout.cy.js
+++ b/cypress/e2e/Logout.cy.js
@@ -7,10 +7,8 @@ beforeEach(() => {
 
 describe('Validate logout scenario and page', () => {
   it('should click Sign-out from the menu item go to /auth/logout/', () => {
-    cy.visit('/auth/logout')
     cy.intercept('POST', 'api/auth/signout').as('signout')
 
-    cy.visit('/my-dashboard')
     cy.get('[data-testid="menuButton"]').click()
     cy.get('[id="dropdownNavbar"]>div:nth-child(5)').click()
 
@@ -24,7 +22,7 @@ describe('Validate logout scenario and page', () => {
     cy.url().should('eq', 'http://localhost:3000/en/auth/logout/')
   })
 
-  it('should show the loading spinner + text the return to index page once logged out', () => {
+  it('should show the loading spinner + text then return to index page once logged out', () => {
     // Create a Promise and capture a reference to its resolve
     // function so that we can resolve it when we want to:
     let sendResponse

--- a/cypress/e2e/dashboard.cy.js
+++ b/cypress/e2e/dashboard.cy.js
@@ -8,12 +8,11 @@ beforeEach(() => {
   cy.visit('/my-dashboard')
 })
 
-it('Dashboard has no detectable a11y violations on load', () => {
-  cy.injectAxe()
-  cy.checkA11y()
-})
-
 describe('Validate dashboard page', () => {
+  it('Dashboard has no detectable a11y violations on load', () => {
+    cy.injectAxe()
+    cy.checkA11y()
+  })
   it('Validate dashboard URL and Header in EN and FR', () => {
     dashboardPo.ValidateDashboardUrl()
     dashboardPo.ValidateDashboardHeaderEN()

--- a/cypress/e2e/termsConditions.cy.js
+++ b/cypress/e2e/termsConditions.cy.js
@@ -8,11 +8,6 @@ beforeEach(() => {
   cy.visit('/privacy-notice-terms-conditions')
 })
 
-it.skip('Terms and conditions and Privacy has no detectable a11y violations on load', () => {
-  cy.injectAxe()
-  cy.checkA11y()
-})
-
 describe('Validate Terms and Conditions Page', () => {
   it('validate the "Terms and Conditions" click on dashboard page goes to Terms and Conditions page', () => {
     cy.visit('/my-dashboard')
@@ -48,5 +43,9 @@ describe('Validate Terms and Conditions Page', () => {
 
   it('Validate the Information section is present on Terms and conditions page', () => {
     termsConditionsPo.ValidateinformationSection()
+  })
+  it.skip('Terms and conditions and Privacy has no detectable a11y violations on load', () => {
+    cy.injectAxe()
+    cy.checkA11y()
   })
 })


### PR DESCRIPTION
## [ADO-135922](https://dev.azure.com/VP-BD/DECD/_workitems/edit/135922)

Fixed [AB#135922](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/135922)

### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary

### Description of proposed changes:
Sometimes the loading spinner was disappearing before the test could see it. This was causing the e2e test to fail randomly.
Changed the tests to check the logout from the menu.
Found a solution that hopefully will prevent the response from continuing until after the spinner has been found, then verify that it continues and logs out as expected. 

### What to test for/How to test
e2e test don't fail randomly

### Additional Notes
