### PR TITLE
Removed DS error page

### DIFF
--- a/__tests__/components/ErrorPage.test.js
+++ b/__tests__/components/ErrorPage.test.js
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { ErrorPage } from '../../components/ErrorPage.js'
+import { axe, toHaveNoViolations } from 'jest-axe'
+
+expect.extend(toHaveNoViolations)
+
+describe('Error Pages', () => {
+  it('has no a11y violations 404', async () => {
+    const { container } = render(<ErrorPage lang="en" errType="404" isAuth />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no a11y violations 500', async () => {
+    const { container } = render(<ErrorPage lang="en" errType="500" isAuth />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no a11y violations 503', async () => {
+    const { container } = render(<ErrorPage lang="en" errType="503" isAuth />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/__tests__/pages/404.test.js
+++ b/__tests__/pages/404.test.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Custom404 from '../../pages/404'
+
+jest.mock('../../graphql/mappers/beta-banner-opt-out', () => ({
+  getBetaBannerContent: () => {
+    return new Promise(function (resolve, reject) {
+      resolve({
+        en: {},
+        fr: {},
+      })
+    })
+  },
+}))
+
+jest.mock('../../graphql/mappers/beta-popup-exit', () => ({
+  getBetaPopupExitContent: () => {
+    return new Promise(function (resolve, reject) {
+      resolve({ en: {}, fr: {} })
+    })
+  },
+}))
+
+describe('custom error', () => {
+  it('renders custom statusCode 404 without crashing', () => {
+    render(
+      <Custom404
+        lang="en"
+        errType="404"
+        isAuth={false}
+        homePageLink={'/en/my-dashboard'}
+        accountPageLink="/"
+      />
+    )
+    const element = screen.getByTestId('errorType')
+    expect(element.textContent).toEqual('Error 404')
+  })
+
+  it('renders custom error page in french without crashing', () => {
+    render(
+      <Custom404
+        lang="fr"
+        errType="404"
+        isAuth={false}
+        homePageLink={'/fr/my-dashboard'}
+        accountPageLink="/"
+      />
+    )
+    const element = screen.getByTestId('errorType')
+    expect(element.textContent).toEqual('Erreur 404')
+  })
+})

--- a/__tests__/pages/500.test.js
+++ b/__tests__/pages/500.test.js
@@ -3,7 +3,7 @@
  */
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import CustomError from '../../pages/_error'
+import Custom500 from '../../pages/500'
 
 jest.mock('../../graphql/mappers/beta-banner-opt-out', () => ({
   getBetaBannerContent: () => {
@@ -27,7 +27,7 @@ jest.mock('../../graphql/mappers/beta-popup-exit', () => ({
 describe('custom error', () => {
   it('renders custom statusCode 500 without crashing', () => {
     render(
-      <CustomError
+      <Custom500
         lang="en"
         errType="500"
         isAuth={false}
@@ -35,32 +35,21 @@ describe('custom error', () => {
         accountPageLink="/"
       />
     )
-    expect(screen.getByText('Error')).toBeInTheDocument()
-  })
-
-  it('renders custom statusCode 404 without crashing', () => {
-    render(
-      <CustomError
-        lang="en"
-        errType="404"
-        isAuth={false}
-        homePageLink={'/en/my-dashboard'}
-        accountPageLink="/"
-      />
-    )
-    expect(screen.getByText('Error')).toBeInTheDocument()
+    const element = screen.getByTestId('errorType')
+    expect(element.textContent).toEqual('Error 500')
   })
 
   it('renders custom error page in french without crashing', () => {
     render(
-      <CustomError
+      <Custom500
         lang="fr"
-        errType="404"
+        errType="500"
         isAuth={false}
         homePageLink={'/fr/my-dashboard'}
         accountPageLink="/"
       />
     )
-    expect(screen.getByText('Erreur')).toBeInTheDocument()
+    const element = screen.getByTestId('errorType')
+    expect(element.textContent).toEqual('Erreur 500')
   })
 })

--- a/components/ErrorPage.js
+++ b/components/ErrorPage.js
@@ -52,7 +52,7 @@ export function ErrorPage(props) {
             <p className="font-bold text-gray-darker sm:text-black text-[20px]">
               {val.errorPageNextText}
             </p>
-            <h2 className="sr-only">What&apos;s Next Links</h2>
+            <h2 className="sr-only">{`What's Next Links`}</h2>
             <ul id={'errorTypes' + index + errType}>
               <li
                 key={'errorLink1' + index.toString()}

--- a/components/ErrorPage.js
+++ b/components/ErrorPage.js
@@ -1,0 +1,147 @@
+import PropTypes from 'prop-types'
+import Heading from './Heading'
+import EN from '../locales/en'
+import FR from '../locales/fr'
+import Link from 'next/link'
+
+export function ErrorPage(props) {
+  const { isAuth, errType, lang, homePageLink, accountPageLink } = props
+  let biClassName = ''
+  let language = lang === 'en' ? [EN] : lang === 'fr' ? [FR] : [EN, FR]
+  if (lang === 'bi') {
+    biClassName = 'grid gap-10 grid-cols-1 sm:grid-cols-2 sm:gap-6'
+  }
+  let errorHeadingEN =
+    errType === '404'
+      ? EN.errorPageHeadingTitle404
+      : errType === '500'
+      ? EN.errorPageHeadingTitle500
+      : EN.errorPageHeadingTitle503
+  let errorHeadingFR =
+    errType === '404'
+      ? FR.errorPageHeadingTitle404
+      : errType === '500'
+      ? FR.errorPageHeadingTitle500
+      : FR.errorPageHeadingTitle503
+
+  let errorTextEN =
+    errType === '404'
+      ? EN.errorPageErrorText404
+      : errType === '500'
+      ? EN.errorPageErrorText500
+      : EN.errorPageErrorText503
+  let errorTextFR =
+    errType === '404'
+      ? FR.errorPageErrorText404
+      : errType === '500'
+      ? FR.errorPageErrorText500
+      : FR.errorPageErrorText503
+  return (
+    <div className={`${biClassName} container`}>
+      {language.map((val, index) => {
+        return (
+          <div key={(val + index).toString()}>
+            <Heading
+              id={'pageHead' + index + errType}
+              title={val === EN ? errorHeadingEN : errorHeadingFR}
+            />
+            <p className="text-20px text-gray-darker mt-2">
+              {val === EN ? errorTextEN : errorTextFR}
+            </p>
+            <br />
+            <p className="font-bold text-gray-darker sm:text-black text-[20px]">
+              {val.errorPageNextText}
+            </p>
+            <h2 className="sr-only">What&apos;s Next Links</h2>
+            <ul id={'errorTypes' + index + errType}>
+              <li
+                key={'errorLink1' + index.toString()}
+                className={
+                  errType === '404'
+                    ? 'hidden'
+                    : 'text-20px text-gray-darker pl-3'
+                }
+              >
+                {errType === '500'
+                  ? val.error500TextLink
+                  : errType === '503'
+                  ? val.error503TextLink
+                  : null}
+              </li>
+              <li
+                key={'errorLink2' + index.toString()}
+                className="text-20px text-gray-darker pl-3"
+              >
+                {!isAuth
+                  ? val.errorTextLinkCommon
+                  : val.errorAuthTextLinkCommon}
+                <Link
+                  className="underline text-deep-blue-dark font-body text-20px hover:text-blue-hover focus:text-blue-hover"
+                  id={
+                    !isAuth
+                      ? 'homePage' + errType + lang + index
+                      : 'accountPage' + errType + lang + index
+                  }
+                  href={!isAuth ? homePageLink : accountPageLink}
+                >
+                  {!isAuth
+                    ? val.errorTextLinkCommon_2
+                    : val.errorAuthTextLinkCommon_2}
+                </Link>
+              </li>
+            </ul>
+            <br />
+            <br />
+            <p
+              data-testid="errorType"
+              className="font-bold text-gray-darker text-[14px] pb-2"
+            >
+              {val.errorPageType} {errType}
+            </p>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+ErrorPage.defaultProps = {
+  accountPageLink: '/',
+  homePageLink: '/',
+  lang: 'en',
+}
+
+ErrorPage.propTypes = {
+  /**
+   * Select the language for the page. If bi is selected
+   * bilingual version of error pages will be used
+   */
+  lang: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf(['en', 'fr', 'bi']),
+  ]).isRequired,
+
+  /**
+   * Select the type of error page you want to use
+   */
+  errType: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf(['404', '500', '503']),
+  ]).isRequired,
+
+  /**
+   * To indicate if the user is authenticated or not
+   * Will display authenticated version of pages if user is authenticated
+   */
+  isAuth: PropTypes.bool.isRequired,
+
+  /**
+   * Add your path to the Service Canada Home Page (not authenticated user)
+   */
+  homePageLink: PropTypes.string,
+
+  /**
+   * Add your path Logged in users account dashboard (authenticated user)
+   */
+  accountPageLink: PropTypes.string,
+}

--- a/locales/en.js
+++ b/locales/en.js
@@ -145,4 +145,27 @@ export default {
   //Authenticated footer links & text
   mscaFooterContactUsText: 'Contact Us',
   mscaFooterHeading: 'My Service Canada Account',
+
+  //Error Pages
+  errorPageHeadingTitle404: "We couldn't find that web page",
+  errorPageHeadingTitle500: "We're having a problem with that page",
+  errorPageHeadingTitle503: 'This service is currently not available',
+  errorPageErrorText404:
+    "We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for.",
+  errorPageErrorText500:
+    "We expect the problem to be fixed shortly. It's not your computer or Internet connection but a problem with our website's server. We apologize for the inconvenience.",
+  errorPageErrorText503:
+    'The web server that provides this service is currently overloaded, or may be temporarily down for maintenance. We apologize for the inconvenience. ',
+  errorPageNextText: ' What next?',
+  errorTextLinkCommon: '• Go to the ',
+  errorTextLinkCommon_2: ' Service Canada home page',
+  errorTextLinkCommonLink:
+    'https://www.canada.ca/en/employment-social-development/corporate/portfolio/service-canada.html',
+  errorAuthTextLinkCommon: '• Go to your ',
+  errorAuthTextLinkCommon_2: 'My Service Canada Account dashboard',
+  errorAuthTextLinkCommonLink:
+    'https://www.canada.ca/en/employment-social-development/services/my-account.html',
+  error500TextLink: '• Try refreshing the page or try again later',
+  error503TextLink: '• Try again later',
+  errorPageType: 'Error',
 }

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -138,4 +138,28 @@ export default {
   //Authenticated footer links & text
   mscaFooterContactUsText: 'Contactez-nous',
   mscaFooterHeading: 'Mon dossier Service Canada',
+
+  //Error Pages
+  errorPageHeadingTitle404: 'Nous ne pouvons trouver cette page Web',
+  errorPageHeadingTitle500: 'Nous éprouvons des difficultés avec cette page',
+  errorPageHeadingTitle503: 'Le service est actuellement indisponible',
+  errorPageErrorText404:
+    "Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez.",
+  errorPageErrorText500:
+    "Nous espérons résoudre le problème sous peu. Il ne s'agit pas d'un problème avec votre ordinateur ou Internet, mais plutôt avec le serveur de notre site Web. Nous nous excusons de cet inconvénient.",
+  errorPageErrorText503:
+    "Le serveur Web auquel vous tentez d'accéder est actuellement surchargé ou pourrait être temporairement hors service à des fins d'entretien. Nous nous excusons de cet inconvénient. ",
+  errorPageNextText: 'Que faire?',
+  errorTextLinkCommon: '• Accéder à la ',
+  errorTextLinkCommon_2: "page d'accueil de Service Canada",
+  errorTextLinkCommonLink:
+    'https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html',
+  errorAuthTextLinkCommon: '• Accéder au ',
+  errorAuthTextLinkCommon_2:
+    'tableau de bord de mon compte Mon dossier Service Canada',
+  errorAuthTextLinkCommonLink:
+    'https://www.canada.ca/fr/emploi-developpement-social/services/mon-dossier.html',
+  error500TextLink: '• Actualisez la page ou réessayez plus tard',
+  error503TextLink: '• Réessayez plus tard',
+  errorPageType: 'Erreur',
 }

--- a/pages/404.js
+++ b/pages/404.js
@@ -62,7 +62,7 @@ export async function getStaticProps({ locale }) {
       bannerContent: bannerContent.en,
       popupContent: popupContent.en,
       meta,
-      isAuth: process.env.AUTH_DISABLED,
+      isAuth: process.env.AUTH_DISABLED ?? true,
     },
   }
 }

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,70 @@
+import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
+import { getBetaBannerContent } from '../graphql/mappers/beta-banner-opt-out'
+import { ErrorPage } from '../components/ErrorPage'
+import { getLogger } from '../logging/log-util'
+
+function Custom404(props) {
+  return (
+    <ErrorPage
+      lang={props.lang ? props.lang : props.locale}
+      errType="404"
+      isAuth={!props?.isAuth}
+      homePageLink={
+        props?.locale === 'en' ? '/en/my-dashboard' : '/fr/mon-tableau-de-bord'
+      }
+      accountPageLink="/"
+    />
+  )
+}
+
+/* istanbul ignore next */
+export async function getStaticProps({ locale }) {
+  //The below sets the minimum logging level to error and surpresses everything below that
+  const logger = getLogger(`404 error page`)
+  logger.level = 'error'
+
+  const bannerContent = await getBetaBannerContent().catch((error) => {
+    logger.error(error)
+    // res.statusCode = 500
+    throw error
+  })
+  const popupContent = await getBetaPopupExitContent().catch((error) => {
+    logger.error(error)
+    // res.statusCode = 500
+    throw error
+  })
+  const langToggleLink = locale === 'en' ? `/fr/404` : `/en/404`
+  /* Place-holder Meta Data Props */
+  const meta = {
+    data_en: {
+      title: `404 - My Service Canada Account`,
+      desc: 'English',
+      author: 'Service Canada',
+      keywords: '',
+      service: 'ESDC-EDSC_MSCA-MSDC',
+      creator: 'Employment and Social Development Canada',
+      accessRights: '1',
+    },
+    data_fr: {
+      title: `404 - Mon dossier Service Canada`,
+      desc: 'Français',
+      author: 'Service Canada',
+      keywords: '',
+      service: 'ESDC-EDSC_MSCA-MSDC',
+      creator: 'Emploi et Développement social Canada',
+      accessRights: '1',
+    },
+  }
+  return {
+    props: {
+      locale: locale ? locale : 'en',
+      langToggleLink,
+      bannerContent: bannerContent.en,
+      popupContent: popupContent.en,
+      meta,
+      isAuth: process.env.AUTH_DISABLED,
+    },
+  }
+}
+
+export default Custom404

--- a/pages/500.js
+++ b/pages/500.js
@@ -1,13 +1,13 @@
 import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
 import { getBetaBannerContent } from '../graphql/mappers/beta-banner-opt-out'
-import { ErrorPage } from '@dts-stn/service-canada-design-system'
+import { ErrorPage } from '../components/ErrorPage'
 import { getLogger } from '../logging/log-util'
 
-function CustomError(props) {
+function Custom500(props) {
   return (
     <ErrorPage
-      lang={props?.locale}
-      errType={props?.statusCode}
+      lang={props.lang ? props.lang : props.locale}
+      errType="500"
       isAuth={!props?.isAuth}
       homePageLink={
         props?.locale === 'en' ? '/en/my-dashboard' : '/fr/mon-tableau-de-bord'
@@ -18,11 +18,9 @@ function CustomError(props) {
 }
 
 /* istanbul ignore next */
-export async function getServerSideProps({ req, res, locale }) {
-  const statusCode = res.statusCode.toString() || '500'
-
+export async function getStaticProps({ locale }) {
   //The below sets the minimum logging level to error and surpresses everything below that
-  const logger = getLogger(`${statusCode} error page`)
+  const logger = getLogger(`500 error page`)
   logger.level = 'error'
 
   const bannerContent = await getBetaBannerContent().catch((error) => {
@@ -35,12 +33,11 @@ export async function getServerSideProps({ req, res, locale }) {
     // res.statusCode = 500
     throw error
   })
-  const langToggleLink =
-    locale === 'en' ? `/fr/${statusCode}` : `/en/${statusCode}`
+  const langToggleLink = locale === 'en' ? `/fr/500` : `/en/500`
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: `${statusCode} - My Service Canada Account`,
+      title: `500 - My Service Canada Account`,
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -49,7 +46,7 @@ export async function getServerSideProps({ req, res, locale }) {
       accessRights: '1',
     },
     data_fr: {
-      title: `${statusCode} - Mon dossier Service Canada`,
+      title: `500 - Mon dossier Service Canada`,
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',
@@ -64,11 +61,10 @@ export async function getServerSideProps({ req, res, locale }) {
       langToggleLink,
       bannerContent: bannerContent.en,
       popupContent: popupContent.en,
-      statusCode,
       meta,
       isAuth: process.env.AUTH_DISABLED,
     },
   }
 }
 
-export default CustomError
+export default Custom500

--- a/pages/500.js
+++ b/pages/500.js
@@ -62,7 +62,7 @@ export async function getStaticProps({ locale }) {
       bannerContent: bannerContent.en,
       popupContent: popupContent.en,
       meta,
-      isAuth: process.env.AUTH_DISABLED,
+      isAuth: process.env.AUTH_DISABLED ?? true,
     },
   }
 }


### PR DESCRIPTION
## [ADO-140370](https://dev.azure.com/VP-BD/DECD/_workitems/edit/140370)

Fixed [AB#140370](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/140370)

### Changelog
fix:remove DS error page
fix:remove custom error page in favor of 404 and 500

### Description of proposed changes:
This PR replaces the DS implementation of the Error page component with a local one. I've also removed the custom error page implementation in favor of individual 404 and 500 pages because the current custom implementation would never redirect to the 500 page as Next would only ever set the status code as 404.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/404` and `/500` and ensure the app works as expected

### Additional Notes
We should explore implementing an error boundary as outlined [here](https://nextjs.org/docs/pages/building-your-application/configuring/error-handling#handling-client-errors) as a way to handle client side errors more gracefully.
