### PR TITLE
Fix French exit beta link

### DIFF
--- a/graphql/mappers/beta-banner-opt-out.js
+++ b/graphql/mappers/beta-banner-opt-out.js
@@ -40,7 +40,7 @@ export async function getBetaBannerContent() {
       bannerButtonLink:
         buildLink(
           resOptOutContent.scFragments[1].schURLType,
-          resOptOutContent.scFragments[1].scDestinationURLEn
+          resOptOutContent.scFragments[1].scDestinationURLFr
         ) || '/',
       icon: resOptOutContent.scFragments[0].scIconCSS,
       id: resOptOutContent.scFragments[0].scId,


### PR DESCRIPTION
### Changelog
fix:update FR exit beta banner link

### Description of proposed changes:
This PR fixes an issue in our exit beta banner mapper that had the EN link mapped to the FR content.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to the dashboard, switch to FR and click `Quitter la version bêta` 
4. Hover over the continue link and ensure `lang=fra` is appended to the end of the link
