### PR TITLE
update h2 and selection of text

### DIFF
--- a/components/contact/ContactProvinceRow.js
+++ b/components/contact/ContactProvinceRow.js
@@ -12,7 +12,10 @@ const ContactProvinceRow = ({ label, items, id }) => {
       <Collapse title={label} id={id} dataTestId={`dataTest`}>
         <div className="grid text-xl grid-cols-2" data-cy="mailContactDetails">
           {items.map((x, i) => (
-            <div className="col-span-2 md:col-span-1 py-3" key={i}>
+            <div
+              className="col-span-2 md:col-span-1 py-3 select-text cursor-default"
+              key={i}
+            >
               <strong className="prose prose-strong:text-xl prose-strong:font-display prose-p:text-xl prose-p:font-display">
                 <Markdown>{`${ap(x.content, ' ')}`}</Markdown>
               </strong>

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -34,7 +34,6 @@ export default function SecuritySettings(props) {
     <div id="securityContent" data-testid="securityContent-test">
       <Heading id="my-dashboard-heading" title={props.content.heading} />
       <p className="mt-3 mb-8 text-xl">{props.content.subHeading}</p>
-
       <Link
         className="underline text-blue-primary font-body text-20px hover:text-blue-hover focus:text-blue-hover"
         id="securityQuestionsLink"
@@ -44,9 +43,7 @@ export default function SecuritySettings(props) {
       >
         {props.content.securityQuestions.linkTitle.text}
       </Link>
-
       <p className="mb-8 text-xl">{props.content.securityQuestions.subTitle}</p>
-
       <Link
         className="underline text-blue-primary font-body text-20px hover:text-blue-hover focus:text-blue-hover"
         id="eiAccessCodeLink"
@@ -56,7 +53,6 @@ export default function SecuritySettings(props) {
       >
         {props.content.eiAccessCode.linkTitle.text}
       </Link>
-
       <p className="pb-7 text-xl">{props.content.eiAccessCode.subTitle}</p>
       <PageLink
         lookingForText={props.content.lookingFor.title}

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -34,26 +34,29 @@ export default function SecuritySettings(props) {
     <div id="securityContent" data-testid="securityContent-test">
       <Heading id="my-dashboard-heading" title={props.content.heading} />
       <p className="mt-3 mb-8 text-xl">{props.content.subHeading}</p>
-      <Link
-        className="underline text-blue-primary font-body text-20px hover:text-blue-hover focus:text-blue-hover"
-        id="securityQuestionsLink"
-        data-testid="securityQuestionsLink"
-        aria-label={props.content.securityQuestions.linkTitle.text}
-        href={props.content.securityQuestions.linkTitle.link}
-      >
-        {props.content.securityQuestions.linkTitle.text}
-      </Link>
+      <h2>
+        <Link
+          className="underline text-blue-primary font-body text-20px hover:text-blue-hover focus:text-blue-hover"
+          id="securityQuestionsLink"
+          data-testid="securityQuestionsLink"
+          aria-label={props.content.securityQuestions.linkTitle.text}
+          href={props.content.securityQuestions.linkTitle.link}
+        >
+          {props.content.securityQuestions.linkTitle.text}
+        </Link>
+      </h2>
       <p className="mb-8 text-xl">{props.content.securityQuestions.subTitle}</p>
-
-      <Link
-        className="underline text-blue-primary font-body text-20px hover:text-blue-hover focus:text-blue-hover"
-        id="eiAccessCodeLink"
-        data-testid="eiAccessCodeLink"
-        aria-label={props.content.eiAccessCode.linkTitle.text}
-        href={props.content.eiAccessCode.linkTitle.link}
-      >
-        {props.content.eiAccessCode.linkTitle.text}
-      </Link>
+      <h2>
+        <Link
+          className="underline text-blue-primary font-body text-20px hover:text-blue-hover focus:text-blue-hover"
+          id="eiAccessCodeLink"
+          data-testid="eiAccessCodeLink"
+          aria-label={props.content.eiAccessCode.linkTitle.text}
+          href={props.content.eiAccessCode.linkTitle.link}
+        >
+          {props.content.eiAccessCode.linkTitle.text}
+        </Link>
+      </h2>
       <p className="pb-7 text-xl">{props.content.eiAccessCode.subTitle}</p>
       <PageLink
         lookingForText={props.content.lookingFor.title}

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -34,29 +34,29 @@ export default function SecuritySettings(props) {
     <div id="securityContent" data-testid="securityContent-test">
       <Heading id="my-dashboard-heading" title={props.content.heading} />
       <p className="mt-3 mb-8 text-xl">{props.content.subHeading}</p>
-      <h2>
-        <Link
-          className="underline text-blue-primary font-body text-20px hover:text-blue-hover focus:text-blue-hover"
-          id="securityQuestionsLink"
-          data-testid="securityQuestionsLink"
-          aria-label={props.content.securityQuestions.linkTitle.text}
-          href={props.content.securityQuestions.linkTitle.link}
-        >
-          {props.content.securityQuestions.linkTitle.text}
-        </Link>
-      </h2>
+
+      <Link
+        className="underline text-blue-primary font-body text-20px hover:text-blue-hover focus:text-blue-hover"
+        id="securityQuestionsLink"
+        data-testid="securityQuestionsLink"
+        aria-label={props.content.securityQuestions.linkTitle.text}
+        href={props.content.securityQuestions.linkTitle.link}
+      >
+        {props.content.securityQuestions.linkTitle.text}
+      </Link>
+
       <p className="mb-8 text-xl">{props.content.securityQuestions.subTitle}</p>
-      <h2>
-        <Link
-          className="underline text-blue-primary font-body text-20px hover:text-blue-hover focus:text-blue-hover"
-          id="eiAccessCodeLink"
-          data-testid="eiAccessCodeLink"
-          aria-label={props.content.eiAccessCode.linkTitle.text}
-          href={props.content.eiAccessCode.linkTitle.link}
-        >
-          {props.content.eiAccessCode.linkTitle.text}
-        </Link>
-      </h2>
+
+      <Link
+        className="underline text-blue-primary font-body text-20px hover:text-blue-hover focus:text-blue-hover"
+        id="eiAccessCodeLink"
+        data-testid="eiAccessCodeLink"
+        aria-label={props.content.eiAccessCode.linkTitle.text}
+        href={props.content.eiAccessCode.linkTitle.link}
+      >
+        {props.content.eiAccessCode.linkTitle.text}
+      </Link>
+
       <p className="pb-7 text-xl">{props.content.eiAccessCode.subTitle}</p>
       <PageLink
         lookingForText={props.content.lookingFor.title}


### PR DESCRIPTION
## [ADO-147429](https://dev.azure.com/VP-BD/DECD/_workitems/edit/147429)

Fixed AB#

### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary

### Description of proposed changes:
a11y changes.
Wrapped the link in an h2 for a11y. 
Made the address information selectable in the chance that someone would want to copy and paste the info. 

### What to test for/How to test
the address text should now allow you to copy and paste it.
The security settings page links are now h2
### Additional Notes
