### PR TITLE
Add req to server side props so auth checks pass

### DIFF
--- a/pages/contact-us/[id].js
+++ b/pages/contact-us/[id].js
@@ -70,7 +70,7 @@ export default function ContactUsPage(props) {
   )
 }
 
-export async function getServerSideProps({ res, locale, params }) {
+export async function getServerSideProps({ req, locale, params }) {
   if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that

--- a/pages/contact-us/index.js
+++ b/pages/contact-us/index.js
@@ -59,7 +59,7 @@ export default function ContactLanding(props) {
   )
 }
 
-export async function getServerSideProps({ res, locale }) {
+export async function getServerSideProps({ req, locale }) {
   if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that

--- a/pages/privacy-notice-terms-conditions.js
+++ b/pages/privacy-notice-terms-conditions.js
@@ -182,7 +182,7 @@ export default function PrivacyCondition(props) {
   )
 }
 
-export async function getServerSideProps({ res, locale }) {
+export async function getServerSideProps({ req, locale }) {
   if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -71,7 +71,7 @@ export default function Profile(props) {
   )
 }
 
-export async function getServerSideProps({ res, locale }) {
+export async function getServerSideProps({ req, locale }) {
   if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -63,7 +63,7 @@ export default function SecuritySettings(props) {
   )
 }
 
-export async function getServerSideProps({ res, locale }) {
+export async function getServerSideProps({ req, locale }) {
   if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that


### PR DESCRIPTION
### Changelog:
fix:Add req to getServerSideProps so page doesn't immediately redirect to 500 on page load

### Description of proposed changes:
This PR fixes an issue where we were doing auth checks on pages without having `req` in `getServerSideProps`.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate through the app and ensure pages load properly
