### PR TITLE
Update Auth functions to use getServerSession

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -11,9 +11,7 @@ export function AuthIsDisabled() {
 export async function AuthIsValid(req, session) {
   const token = await jwt.getToken({ req })
   if (session && token) {
-    if (token.provider !== 'credentials') {
-      await ValidateSession(process.env.CLIENT_ID, token.sub)
-    }
+    await ValidateSession(process.env.CLIENT_ID, token.sub)
     return true
   }
   return false

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,6 +1,5 @@
-import { getSession } from 'next-auth/react'
 import * as jwt from 'next-auth/jwt'
-import axios from 'axios'
+// import axios from 'axios'
 
 export function AuthIsDisabled() {
   return (
@@ -9,59 +8,66 @@ export function AuthIsDisabled() {
   )
 }
 
-export async function AuthIsValid(req) {
-  const session = await getSession({ req })
+export async function AuthIsValid(req, session) {
   const token = await jwt.getToken({ req })
   if (session && token) {
-    await ValidateSession(process.env.CLIENT_ID, token.sub)
+    if (token.provider !== 'credentials') {
+      await ValidateSession(process.env.CLIENT_ID, token.sub)
+    }
     return true
   }
   return false
 }
 
 export async function ValidateSession(clientId, sharedSessionId) {
-  console.log('Renewing session...')
+  // console.log('Renewing session...')
 
   //Necessary to test locally until we no longer need the proxy. Will use request without proxy on deployed app
-  process.env.AUTH_ON_PROXY &&
-  process.env.AUTH_ON_PROXY.toLowerCase() === 'true'
-    ? axios
-        .get(
-          process.env.AUTH_ECAS_REFRESH_ENDPOINT +
-            `?client_id=${clientId}&shared_session_id=${sharedSessionId}`,
-          {
-            proxy: {
-              protocol: 'http',
-              host: 'localhost',
-              port: 3128,
-            },
-          }
-        )
-        .then((response) => {
-          if (response.data === true) {
-            console.log('Session renewed!')
-          }
-        })
-        .catch((error) => console.error(error))
-    : axios
-        .get(
-          process.env.AUTH_ECAS_REFRESH_ENDPOINT +
-            `?client_id=${clientId}&shared_session_id=${sharedSessionId}`
-        )
-        .then((response) => {
-          if (response.data === true) {
-            console.log('Session renewed!')
-          }
-        })
-        .catch((error) => console.error(error))
+  //   process.env.AUTH_ON_PROXY &&
+  //   process.env.AUTH_ON_PROXY.toLowerCase() === 'true'
+  //     ? axios
+  //         .get(
+  //           process.env.AUTH_ECAS_REFRESH_ENDPOINT +
+  //             `?client_id=${clientId}&shared_session_id=${sharedSessionId}`,
+  //           {
+  //             proxy: {
+  //               protocol: 'http',
+  //               host: 'localhost',
+  //               port: 3128,
+  //             },
+  //           }
+  //         )
+  //         .then((response) => {
+  //           if (response.data === true) {
+  //             console.log('Session renewed!')
+  //           }
+  //         })
+  //         .catch((error) => console.error(error))
+  //     : axios
+  //         .get(
+  //           process.env.AUTH_ECAS_REFRESH_ENDPOINT +
+  //             `?client_id=${clientId}&shared_session_id=${sharedSessionId}`
+  //         )
+  //         .then((response) => {
+  //           if (response.data === true) {
+  //             console.log('Session renewed!')
+  //           }
+  //         })
+  //         .catch((error) => console.error(error))
+  // }
+
+  //Removed axios request for now until issue can be resolved so as to not bog up our logs
+  console.log(
+    process.env.AUTH_ECAS_REFRESH_ENDPOINT +
+      `?client_id=${clientId}&shared_session_id=${sharedSessionId}`
+  )
 }
 
 export async function getToken(req) {
   return jwt.getToken(req)
 }
 
-export async function getLogoutURL(req) {
-  const session = await getSession({ req })
+export async function getLogoutURL(req, session) {
   const token = await jwt.getToken({ req })
 
   if (session && token) {

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,5 @@
 import NextAuth from 'next-auth'
+import { NextAuthOptions } from 'next-auth'
 
 import { getLogger } from '../../../logging/log-util'
 
@@ -6,10 +7,7 @@ import { getLogger } from '../../../logging/log-util'
 const logger = getLogger('next-auth')
 logger.level = 'warn'
 
-// For more information on each option (and a full list of options) go to
-// https://next-auth.js.org/configuration/options
-export default NextAuth({
-  // https://next-auth.js.org/configuration/providers/oauth
+export const authOptions: NextAuthOptions = {
   providers: [
     {
       id: 'ecasProvider',
@@ -31,8 +29,14 @@ export default NextAuth({
         token_endpoint_auth_signing_alg: 'RS256',
         id_token_signed_response_alg: 'RS512',
       },
+      token: {
+        url: 'https://srv241-s2.lab.hrdc-drhc.gc.ca/ecas-seca/raoidc_ii/v1/token',
+        params: {
+          scope: 'openid profile',
+        },
+      },
       jwks: {
-        keys: [JSON.parse(process.env.AUTH_PRIVATE)],
+        keys: [JSON.parse(process.env.AUTH_PRIVATE ?? '{}')],
       },
       userinfo: process.env.AUTH_ECAS_USERINFO,
       idToken: true,
@@ -46,11 +50,14 @@ export default NextAuth({
   ],
   theme: {
     colorScheme: 'light',
+    logo: 'https://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg',
   },
-  session: { jwt: true },
+  session: {
+    strategy: 'jwt',
+  },
   callbacks: {
-    async jwt({ token, user, account }) {
-      return token
+    async jwt({ token, account }) {
+      return { ...token, ...account }
     },
     async redirect({ url, baseUrl }) {
       // Allows relative callback URLs
@@ -69,12 +76,9 @@ export default NextAuth({
     warn(code) {
       logger.warn(code)
     },
-    debug(code, metadata) {
-      logger.error(code)
-      logger.error(metadata)
-    },
   },
   pages: {
     signIn: '/auth/login/',
   },
-})
+}
+export default NextAuth(authOptions)

--- a/pages/api/refresh-msca.js
+++ b/pages/api/refresh-msca.js
@@ -5,18 +5,22 @@
 
 import { AuthIsDisabled, AuthIsValid } from '../../lib/auth'
 import { getLogger } from '../../logging/log-util'
+import { authOptions } from 'pages/api/auth/[...nextauth]'
+import { getServerSession } from 'next-auth/next'
 
 //The below sets the minimum logging level to error and surpresses everything below that
 const logger = getLogger('refresh-msca')
 logger.level = 'error'
 
 export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions)
+
   if (req.method === 'GET') {
     //Send request to ECAS to refresh MSCA session
     if (AuthIsDisabled()) {
       //Service unavailable when auth is disabled
       res.status(503).json({ success: false })
-    } else if (await AuthIsValid(req)) {
+    } else if (await AuthIsValid(req, session)) {
       res.status(200).json({ success: true })
     } else {
       res.status(500).json({ success: false })

--- a/pages/auth/logout.js
+++ b/pages/auth/logout.js
@@ -1,5 +1,7 @@
 import { useEffect } from 'react'
 import { getLogoutURL, AuthIsDisabled } from '../../lib/auth'
+import { authOptions } from 'pages/api/auth/[...nextauth]'
+import { getServerSession } from 'next-auth/next'
 import LoadingSpinner from '../../components/LoadingSpinner'
 import { signOut } from 'next-auth/react'
 import MetaData from '../../components/MetaData'
@@ -35,12 +37,14 @@ Logout.getLayout = function PageLayout(page) {
 }
 
 export async function getServerSideProps({ req, res, locale }) {
+  const session = await getServerSession(req, res, authOptions)
+
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('logout')
   logger.level = 'error'
 
   const logoutURL = !AuthIsDisabled()
-    ? await getLogoutURL(req).catch((error) => {
+    ? await getLogoutURL(req, session).catch((error) => {
         logger.error(error)
         res.statusCode = 500
         throw error

--- a/pages/contact-us/[id].js
+++ b/pages/contact-us/[id].js
@@ -13,6 +13,8 @@ import { getAuthModalsContent } from '../../graphql/mappers/auth-modals'
 import { getContactUsPage } from '../../graphql/mappers/contact-us-pages-dynamic'
 import { getLogger } from '../../logging/log-util'
 import { AuthIsDisabled, AuthIsValid, Redirect } from '../../lib/auth'
+import { authOptions } from 'pages/api/auth/[...nextauth]'
+import { getServerSession } from 'next-auth/next'
 import React from 'react'
 import { useEffect, useCallback, useMemo } from 'react'
 import throttle from 'lodash.throttle'
@@ -70,8 +72,10 @@ export default function ContactUsPage(props) {
   )
 }
 
-export async function getServerSideProps({ req, locale, params }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+export async function getServerSideProps({ req, res, locale, params }) {
+  const session = await getServerSession(req, res, authOptions)
+
+  if (!AuthIsDisabled() && !(await AuthIsValid(req, session))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger(params.id)

--- a/pages/contact-us/index.js
+++ b/pages/contact-us/index.js
@@ -9,6 +9,8 @@ import { getContactUsContent } from '../../graphql/mappers/contact-us'
 import { getBetaBannerContent } from '../../graphql/mappers/beta-banner-opt-out'
 import { getBetaPopupExitContent } from '../../graphql/mappers/beta-popup-exit'
 import { AuthIsDisabled, AuthIsValid, Redirect } from '../../lib/auth'
+import { authOptions } from 'pages/api/auth/[...nextauth]'
+import { getServerSession } from 'next-auth/next'
 import { useEffect, useCallback, useMemo } from 'react'
 import throttle from 'lodash.throttle'
 import { getLogger } from '../../logging/log-util'
@@ -61,8 +63,10 @@ export default function ContactLanding(props) {
   )
 }
 
-export async function getServerSideProps({ req, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+export async function getServerSideProps({ req, res, locale }) {
+  const session = await getServerSession(req, res, authOptions)
+
+  if (!AuthIsDisabled() && !(await AuthIsValid(req, session))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('contact-us')

--- a/pages/decision-reviews.js
+++ b/pages/decision-reviews.js
@@ -8,6 +8,8 @@ import { getBetaBannerContent } from '../graphql/mappers/beta-banner-opt-out'
 import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
 import { getLogger } from '../logging/log-util'
 import { AuthIsDisabled, AuthIsValid, Redirect } from '../lib/auth'
+import { authOptions } from 'pages/api/auth/[...nextauth]'
+import { getServerSession } from 'next-auth/next'
 import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-page-not-available'
 import { getAuthModalsContent } from '../graphql/mappers/auth-modals'
 import React from 'react'
@@ -130,8 +132,10 @@ export default function DecisionReviews(props) {
   )
 }
 
-export async function getServerSideProps({ req, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+export async function getServerSideProps({ req, res, locale }) {
+  const session = await getServerSession(req, res, authOptions)
+
+  if (!AuthIsDisabled() && !(await AuthIsValid(req, session))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('decision-reviews')

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -11,6 +11,8 @@ import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-p
 import { getAuthModalsContent } from '../graphql/mappers/auth-modals'
 import { getLogger } from '../logging/log-util'
 import { AuthIsDisabled, AuthIsValid, Redirect } from '../lib/auth'
+import { authOptions } from 'pages/api/auth/[...nextauth]'
+import { getServerSession } from 'next-auth/next'
 import BenefitTasks from './../components/BenefitTasks'
 import MostReqTasks from './../components/MostReqTasks'
 import React from 'react'
@@ -116,7 +118,9 @@ export default function MyDashboard(props) {
 }
 
 export async function getServerSideProps({ req, res, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+  const session = await getServerSession(req, res, authOptions)
+
+  if (!AuthIsDisabled() && !(await AuthIsValid(req, session))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('my-dashboard')

--- a/pages/privacy-notice-terms-conditions.js
+++ b/pages/privacy-notice-terms-conditions.js
@@ -10,6 +10,8 @@ import { getBetaBannerContent } from '../graphql/mappers/beta-banner-opt-out'
 import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
 import { getLogger } from '../logging/log-util'
 import { AuthIsDisabled, AuthIsValid, Redirect } from '../lib/auth'
+import { authOptions } from 'pages/api/auth/[...nextauth]'
+import { getServerSession } from 'next-auth/next'
 import BackToButton from '../components/BackToButton'
 import Markdown from 'markdown-to-jsx'
 import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-page-not-available'
@@ -190,7 +192,9 @@ export default function PrivacyCondition(props) {
 }
 
 export async function getServerSideProps({ req, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+  const session = await getServerSession(req, res, authOptions)
+
+  if (!AuthIsDisabled() && !(await AuthIsValid(req, session))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('privacy-notice-terms-and-conditions')

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -10,6 +10,8 @@ import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-p
 import { getAuthModalsContent } from '../graphql/mappers/auth-modals'
 import { getLogger } from '../logging/log-util'
 import { AuthIsDisabled, AuthIsValid, Redirect } from '../lib/auth'
+import { authOptions } from 'pages/api/auth/[...nextauth]'
+import { getServerSession } from 'next-auth/next'
 import ProfileTasks from './../components/ProfileTasks'
 import React from 'react'
 import { useEffect, useCallback, useMemo } from 'react'
@@ -71,8 +73,10 @@ export default function Profile(props) {
   )
 }
 
-export async function getServerSideProps({ req, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+export async function getServerSideProps({ req, res, locale }) {
+  const session = await getServerSession(req, res, authOptions)
+
+  if (!AuthIsDisabled() && !(await AuthIsValid(req, session))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('profile')

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -11,6 +11,8 @@ import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-p
 import { getAuthModalsContent } from '../graphql/mappers/auth-modals'
 import { getLogger } from '../logging/log-util'
 import { AuthIsDisabled, AuthIsValid, Redirect } from '../lib/auth'
+import { authOptions } from 'pages/api/auth/[...nextauth]'
+import { getServerSession } from 'next-auth/next'
 import { useEffect, useCallback, useMemo } from 'react'
 import throttle from 'lodash.throttle'
 
@@ -67,8 +69,10 @@ export default function SecuritySettings(props) {
   )
 }
 
-export async function getServerSideProps({ req, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+export async function getServerSideProps({ req, res, locale }) {
+  const session = await getServerSession(req, res, authOptions)
+
+  if (!AuthIsDisabled() && !(await AuthIsValid(req, session))) return Redirect()
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('security-settings')


### PR DESCRIPTION
## [ADO-153418](https://dev.azure.com/VP-BD/DECD/_workitems/edit/153418)

Fixed [AB#153418](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/153418)

### Changelog
fix:Update auth functions to use getServerSession instead of getSession

### Description of proposed changes:
This PR updates two of our Auth functions (`AuthIsValid` and `getLogoutURL`) to take in session as a parameter instead of accessing session information from the `getSession` function. The `getSession` function was never meant to be consumed server side even though it does technically work. Hoping this will cut down on some client fetch errors we're seeing in production.

### What to test for/How to test
1. Pull in branch
2. Type `npm run build` and `npm run start`
3. Ensure application runs as expected
### Additional Notes
