### PR TITLE
Update auth redirect to account for FR

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -73,11 +73,11 @@ export async function getLogoutURL(req) {
   return
 }
 
-export function Redirect() {
+export function Redirect(locale) {
   return {
     redirect: {
       permanent: false,
-      destination: '/api/auth/signin',
+      destination: `/${locale}/auth/login`,
     },
   }
 }

--- a/pages/auth/login.js
+++ b/pages/auth/login.js
@@ -15,15 +15,20 @@ export default function Login(props) {
       //If auth is disabled, redirect to dashboard without triggering signIn event, for testing purposes only
       if (props.authDisabled) {
         setTimeout(() => {
-          router.push('/my-dashboard')
+          props.locale === 'en'
+            ? router.push('/en/my-dashboard')
+            : router.push('/fr/mon-tableau-de-bord')
         }, 3000)
         return
       }
       signIn('ecasProvider', {
-        callbackUrl: `${window.location.origin}/my-dashboard`,
+        callbackUrl:
+          props.locale === 'en'
+            ? `${window.location.origin}/en/my-dashboard`
+            : `${window.location.origin}/fr/mon-tableau-de-bord`,
       })
     }
-  }, [router.isReady, props.authDisabled, router])
+  }, [router.isReady, props.authDisabled, router, props.locale])
 
   return (
     <div role="main">

--- a/pages/contact-us/[id].js
+++ b/pages/contact-us/[id].js
@@ -98,7 +98,7 @@ export default function ContactUsPage(props) {
 }
 
 export async function getServerSideProps({ req, locale, params }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect(locale)
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger(params.id)

--- a/pages/contact-us/index.js
+++ b/pages/contact-us/index.js
@@ -89,7 +89,7 @@ export default function ContactLanding(props) {
 }
 
 export async function getServerSideProps({ req, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect(locale)
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('contact-us')

--- a/pages/decision-reviews.js
+++ b/pages/decision-reviews.js
@@ -135,7 +135,7 @@ export default function DecisionReviews(props) {
 }
 
 export async function getServerSideProps({ req, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect(locale)
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('decision-reviews')

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -116,7 +116,7 @@ export default function MyDashboard(props) {
 }
 
 export async function getServerSideProps({ req, res, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect(locale)
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('my-dashboard')

--- a/pages/privacy-notice-terms-conditions.js
+++ b/pages/privacy-notice-terms-conditions.js
@@ -190,7 +190,7 @@ export default function PrivacyCondition(props) {
 }
 
 export async function getServerSideProps({ req, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect(locale)
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('privacy-notice-terms-and-conditions')

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -99,7 +99,7 @@ export default function Profile(props) {
 }
 
 export async function getServerSideProps({ req, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect(locale)
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('profile')

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -96,7 +96,7 @@ export default function SecuritySettings(props) {
 }
 
 export async function getServerSideProps({ req, locale }) {
-  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect()
+  if (!AuthIsDisabled() && !(await AuthIsValid(req))) return Redirect(locale)
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('security-settings')


### PR DESCRIPTION
## [ADO-155852](https://dev.azure.com/VP-BD/DECD/_workitems/edit/155852)

Fixed [AB#155852](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/155852)

### Changelog
fix:update auth redirect to account for French locale

### Description of proposed changes:
Currently, regardless of what language a user navigates to on a page before being authenticated, they are redirected to `/en/auth/login` to authenticate. Since the locale is then set to `en`, the user would be redirected to the English page. This PR updates the `Redirect` function in our auth helper functions file to redirect based on the locale passed to it, and also updates the callbackURL on the signIn function on our custom sign in page.

### What to test for/How to test
1. Pull in branch
2. Ensure `AUTH_DISABLED` is set to `false`
3. Type `npm run dev`
4. Click English to be redirected to the stream links page
5. Select SYS2 Stream 1
6. Login with GCKey
7. Once confirming you are logged in by landing on the MSCA landing page, manually navigate to `localhost:3000/fr/mon-tableau-de-bord`
8. Ensure that you are redirected to `/fr/auth/login` and then `/fr/mon-tableau-de-bord`
