### PR TITLE
Update jwt to have max age of 20 mins

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -54,6 +54,7 @@ export const authOptions: NextAuthOptions = {
   },
   session: {
     strategy: 'jwt',
+    maxAge: 5 * 10 * 24, //20 minutes
   },
   callbacks: {
     async jwt({ token, account }) {


### PR DESCRIPTION
## [ADO-155827](https://dev.azure.com/VP-BD/DECD/_workitems/edit/155827)

Fixed [AB#155827](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/155827)

### Changelog
fix:add maxAge to session cookie

### Description of proposed changes:
This PR adds a maxAge of 20 minutes to our session cookie to match with MSCA. The MSCA session will be refreshed each time a user interacts with SCCH so in the event our session cookie expires while the user is still using the site, it will redirect to our `/auth/login` endpoint and re-link the with still valid MSCA session, then redirecting the user back to the dashboard.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Login via GCKey
4. Manually redirect to `localhost:3000/en/my-dashboard`
5. Right click, click inspect (or F12 depending on what browser you're using)
6. In Firefox, select the Storage tab (on chrome browsers, select the Application tab, as all the storage info is there)
7. Under session storage there should be 3 next-auth cookies. One of them corresponds to the session and should have an expiry set 20 minutes from when you login

### Additional Notes
Still need to look into a way of having this token being refreshed at the same intervals that we're refreshing the MSCA session.