### PR TITLE
Index middleware flag

### DIFF
--- a/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
@@ -20,6 +20,8 @@ extraEnv:
           key: example-secret-password         
 */}}
 extraEnv:
+  - name: NODE_ENV
+    value: {{ env "NODE_ENV" | default "development" }}
   - name: LOGGING_LEVEL
     value: {{ env "LOGGING_LEVEL" | default "error" }}
   - name: OTEL_ENVIRONMENT

--- a/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
@@ -21,7 +21,7 @@ extraEnv:
 */}}
 extraEnv:
   - name: NODE_ENV
-    value: {{ env "NODE_ENV" | default "development" }}
+    value: {{ env "ENVIRONMENT" | default "development" }}
   - name: LOGGING_LEVEL
     value: {{ env "LOGGING_LEVEL" | default "error" }}
   - name: OTEL_ENVIRONMENT

--- a/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
@@ -20,7 +20,7 @@ extraEnv:
           key: example-secret-password         
 */}}
 extraEnv:
-  - name: NODE_ENV
+  - name: ENVIRONMENT
     value: {{ env "ENVIRONMENT" | default "development" }}
   - name: LOGGING_LEVEL
     value: {{ env "LOGGING_LEVEL" | default "error" }}

--- a/helmfile/overrides/secure-client-hub/prod/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/prod/secure-client-hub.yaml.gotmpl
@@ -20,6 +20,8 @@ extraEnv:
           key: example-secret-password         
 */}}
 extraEnv:
+  - name: NODE_ENV
+    value: {{ env "NODE_ENV" | default "production" }}
   - name: LOGGING_LEVEL
     value: {{ env "LOGGING_LEVEL" | default "error" }}
   - name: OTEL_ENVIRONMENT

--- a/helmfile/overrides/secure-client-hub/prod/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/prod/secure-client-hub.yaml.gotmpl
@@ -21,7 +21,7 @@ extraEnv:
 */}}
 extraEnv:
   - name: NODE_ENV
-    value: {{ env "NODE_ENV" | default "production" }}
+    value: {{ env "ENVIRONMENT" | default "production" }}
   - name: LOGGING_LEVEL
     value: {{ env "LOGGING_LEVEL" | default "error" }}
   - name: OTEL_ENVIRONMENT

--- a/helmfile/overrides/secure-client-hub/prod/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/prod/secure-client-hub.yaml.gotmpl
@@ -20,7 +20,7 @@ extraEnv:
           key: example-secret-password         
 */}}
 extraEnv:
-  - name: NODE_ENV
+  - name: ENVIRONMENT
     value: {{ env "ENVIRONMENT" | default "production" }}
   - name: LOGGING_LEVEL
     value: {{ env "LOGGING_LEVEL" | default "error" }}

--- a/lib/hooks/usePublicRuntimeConfig.ts
+++ b/lib/hooks/usePublicRuntimeConfig.ts
@@ -7,14 +7,14 @@ import { publicRuntimeConfigSchema } from '../schemas/public-runtime-config-sche
 export const usePublicRuntimeConfig = () => {
   const config = getConfig()
 
-  const { LOGGING_LEVEL, NODE_ENV } = config?.publicRuntimeConfig ?? {}
+  const { LOGGING_LEVEL, ENVIRONMENT } = config?.publicRuntimeConfig ?? {}
 
   return useMemo(
     () =>
       publicRuntimeConfigSchema.validateSync({
         LOGGING_LEVEL,
-        NODE_ENV,
+        ENVIRONMENT,
       }),
-    [LOGGING_LEVEL, NODE_ENV]
+    [LOGGING_LEVEL, ENVIRONMENT]
   )
 }

--- a/lib/hooks/usePublicRuntimeConfig.ts
+++ b/lib/hooks/usePublicRuntimeConfig.ts
@@ -7,13 +7,14 @@ import { publicRuntimeConfigSchema } from '../schemas/public-runtime-config-sche
 export const usePublicRuntimeConfig = () => {
   const config = getConfig()
 
-  const { LOGGING_LEVEL } = config?.publicRuntimeConfig ?? {}
+  const { LOGGING_LEVEL, NODE_ENV } = config?.publicRuntimeConfig ?? {}
 
   return useMemo(
     () =>
       publicRuntimeConfigSchema.validateSync({
         LOGGING_LEVEL,
+        NODE_ENV,
       }),
-    [LOGGING_LEVEL]
+    [LOGGING_LEVEL, NODE_ENV]
   )
 }

--- a/lib/schemas/public-runtime-config-schema.ts
+++ b/lib/schemas/public-runtime-config-schema.ts
@@ -11,11 +11,19 @@ export const levelsWithSilent: ReadonlyArray<LevelWithSilent> = [
   'warn',
 ]
 
+export const allowedEnvironments: string[] = ['production', 'development']
+
 export const publicRuntimeConfigSchema = yup.object({
   LOGGING_LEVEL: yup
     .string()
     .oneOf(
       levelsWithSilent,
+      'Env. variable ${path} must be one of the following values: ${values}'
+    ),
+  ENVIRONMENT: yup
+    .string()
+    .oneOf(
+      allowedEnvironments,
       'Env. variable ${path} must be one of the following values: ${values}'
     ),
 })

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,9 +9,6 @@ export async function middleware(req: NextRequest) {
   const { locale, pathname } = nextUrl
   const logger = getLogger('middleware')
 
-  console.log(process.env.ENVIRONMENT)
-
-  logger.trace(`Environment: [${process.env.NODE_ENV}]`)
   logger.trace(`Incoming request for [${url}]`)
 
   if (

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,8 @@ export async function middleware(req: NextRequest) {
   const { locale, pathname } = nextUrl
   const logger = getLogger('middleware')
 
+  console.log(process.env.ENVIRONMENT)
+
   logger.trace(`Environment: [${process.env.NODE_ENV}]`)
   logger.trace(`Incoming request for [${url}]`)
 
@@ -30,7 +32,7 @@ export async function middleware(req: NextRequest) {
   }
 
   //Redirect for index page as we don't want users navigating to this page on prod
-  if (pathname === '/' && process.env.NODE_ENV === 'production') {
+  if (pathname === '/' && process.env.ENVIRONMENT === 'production') {
     return NextResponse.redirect(new URL(`/en/my-dashboard`, url))
   }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,7 @@ export async function middleware(req: NextRequest) {
   const { locale, pathname } = nextUrl
   const logger = getLogger('middleware')
 
+  logger.trace(`Environment: [${process.env.NODE_ENV}]`)
   logger.trace(`Incoming request for [${url}]`)
 
   if (
@@ -26,6 +27,11 @@ export async function middleware(req: NextRequest) {
   //Redirect for index page as it's meant to be bilingual so we don't want users navigating to /en or /fr
   if ((locale === 'en' || locale === 'fr') && pathname === '/') {
     return NextResponse.redirect(new URL(`/`, url))
+  }
+
+  //Redirect for index page as we don't want users navigating to this page on prod
+  if (pathname === '/' && process.env.NODE_ENV === 'production') {
+    return NextResponse.redirect(new URL(`/en/my-dashboard`, url))
   }
 
   return NextResponse.next()

--- a/next.config.js
+++ b/next.config.js
@@ -76,6 +76,7 @@ const securityHeaders = [
 module.exports = {
   publicRuntimeConfig: {
     LOGGING_LEVEL: process.env.LOGGING_LEVEL ?? 'info',
+    NODE_ENV: process.env.NODE_ENV ?? 'production',
   },
   reactStrictMode: true,
   //

--- a/next.config.js
+++ b/next.config.js
@@ -76,7 +76,7 @@ const securityHeaders = [
 module.exports = {
   publicRuntimeConfig: {
     LOGGING_LEVEL: process.env.LOGGING_LEVEL ?? 'info',
-    NODE_ENV: process.env.NODE_ENV ?? 'production',
+    ENVIRONMENT: process.env.ENVIRONMENT,
   },
   reactStrictMode: true,
   //


### PR DESCRIPTION
## [ADO-157573](https://dev.azure.com/VP-BD/DECD/_workitems/edit/157573)

Fixed [AB#157573](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/157573)

### Changelog
fix:make splash page inaccessible on prod

### Description of proposed changes:
This PR adds a middleware rule that redirects the user to the dashboard (or `/auth/login`) in the event they navigate to the splash page on prod. This redirect will not happen on our development environments.

### What to test for/How to test
1. Pull in branch
2. Add `ENVIRONMENT=production` to you `.env.local`
3. Type `npm run dev`
4. Ensure that going to `/` redirects you to `/en/my-dashboard` (if auth is disabled, if enabled you should be redirects to `/auth/login`)
