### PR TITLE
Update logging in ValidateSession to use pino

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -51,7 +51,7 @@ export async function ValidateSession(clientId, sharedSessionId) {
         )
         .then((response) => {
           if (response.data === true) {
-            logger.trace('Session renewed')
+            logger.trace('Session renewed!')
           }
         })
         .catch((error) => logger.error(error))

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,6 +1,8 @@
-import { getSession } from 'next-auth/react'
 import * as jwt from 'next-auth/jwt'
 import axios from 'axios'
+import { getLogger } from '../logging/log-util'
+
+const logger = getLogger('auth-helpers')
 
 export function AuthIsDisabled() {
   return (
@@ -19,7 +21,7 @@ export async function AuthIsValid(req, session) {
 }
 
 export async function ValidateSession(clientId, sharedSessionId) {
-  console.log('Renewing session...')
+  logger.trace('Renewing session...')
 
   //Necessary to test locally until we no longer need the proxy. Will use request without proxy on deployed app
   process.env.AUTH_ON_PROXY &&
@@ -38,10 +40,10 @@ export async function ValidateSession(clientId, sharedSessionId) {
         )
         .then((response) => {
           if (response.data === true) {
-            console.log('Session renewed!')
+            logger.trace('Session renewed!')
           }
         })
-        .catch((error) => console.error(error))
+        .catch((error) => logger.error(error))
     : axios
         .get(
           process.env.AUTH_ECAS_REFRESH_ENDPOINT +
@@ -49,10 +51,10 @@ export async function ValidateSession(clientId, sharedSessionId) {
         )
         .then((response) => {
           if (response.data === true) {
-            console.log('Session renewed!')
+            logger.trace('Session renewed')
           }
         })
-        .catch((error) => console.error(error))
+        .catch((error) => logger.error(error))
 }
 
 export async function getToken(req) {


### PR DESCRIPTION
### Changelog
fix:update ValidateSession to use pino logging

### Description of proposed changes:
This PR updates our ValidateSession auth function to use our logger instead of using `console.log`. This will allow us to turn off trace logging at some point so our logs aren't getting flooded by logs from renewing the session.

### What to test for/How to test
1. Pull in branch
2. Ensure auth is enabled and log level is set to trace
3. Connect to proxy
4. Type `npm run dev`
5. Login and once on SCCH navigate through the pages ensuring the logs are being output to the console