### PR TITLE
update meta to match h1 for page

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -65,7 +65,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: `404 - My Service Canada Account`,
+      title: `We couldn't find that web page - 404 - My Service Canada Account`,
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -74,7 +74,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       accessRights: '1',
     },
     data_fr: {
-      title: `404 - Mon dossier Service Canada`,
+      title: `Nous ne pouvons trouver cette page Web - 404 - Mon dossier Service Canada`,
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -65,7 +65,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: `500 - My Service Canada Account`,
+      title: `We couldn't find that web page - 500 - My Service Canada Account`,
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -74,7 +74,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       accessRights: '1',
     },
     data_fr: {
-      title: `500 - Mon dossier Service Canada`,
+      title: `Nous ne pouvons trouver cette page Web - 500 - Mon dossier Service Canada`,
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/decision-reviews.js
+++ b/pages/decision-reviews.js
@@ -191,7 +191,7 @@ export async function getServerSideProps({ req, res, locale }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: 'Request Review Decison - My Service Canada Account',
+      title: 'Request a review of a decision - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -200,7 +200,7 @@ export async function getServerSideProps({ req, res, locale }) {
       accessRights: '1',
     },
     data_fr: {
-      title: 'Demande de revision - Mon dossier Service Canada',
+      title: 'Faire une demande de révision - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/maintenance.tsx
+++ b/pages/maintenance.tsx
@@ -71,7 +71,8 @@ export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
 
   const meta = {
     data_en: {
-      title: 'Maintenance - My Service Canada Account',
+      title:
+        'This service is currently unavailable - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -80,7 +81,8 @@ export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
       accessRights: '1',
     },
     data_fr: {
-      title: 'Entretien - Mon dossier Service Canada',
+      title:
+        'Le service est actuellement indisponible - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -169,7 +169,7 @@ export async function getServerSideProps({ req, res, locale }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: 'Dashboard - My Service Canada Account',
+      title: 'My dashboard - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -178,7 +178,7 @@ export async function getServerSideProps({ req, res, locale }) {
       accessRights: '1',
     },
     data_fr: {
-      title: 'Tableau de Bord - Mon dossier Service Canada',
+      title: 'Mon tableau de bord - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/privacy-notice-terms-conditions.js
+++ b/pages/privacy-notice-terms-conditions.js
@@ -268,7 +268,8 @@ export async function getServerSideProps({ req, res, locale }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: 'Privacy and Conditions - My Service Canada Account',
+      title:
+        'Privacy notice and terms and conditions - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -277,7 +278,8 @@ export async function getServerSideProps({ req, res, locale }) {
       accessRights: '1',
     },
     data_fr: {
-      title: 'Confidentialité et conditions - Mon dossier Service Canada',
+      title:
+        'Avis de confidentialité et modalités - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -169,7 +169,7 @@ export async function getServerSideProps({ req, res, locale }) {
   /* Place-holder Meta Data Props */
   const meta = {
     data_en: {
-      title: 'Security - My Service Canada Account',
+      title: 'Security settings - My Service Canada Account',
       desc: 'English',
       author: 'Service Canada',
       keywords: '',
@@ -178,7 +178,7 @@ export async function getServerSideProps({ req, res, locale }) {
       accessRights: '1',
     },
     data_fr: {
-      title: 'Sécurité - Mon dossier Service Canada',
+      title: 'Paramètres de sécurité - Mon dossier Service Canada',
       desc: 'Français',
       author: 'Service Canada',
       keywords: '',


### PR DESCRIPTION
## [ADO-175255](https://dev.azure.com/VP-BD/DECD/_workitems/edit/175255)

[AB#175255](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/175255)

### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary
fix: update meta tag to match h1 of the page.

### Description of proposed changes:
Update the meta tags so that they match the h1 as requested by the AA team. 

Note that the contact-us and contact-us dynamic page are in a different PR. 

### What to test for/How to test

### Additional Notes
