### PR TITLE
Adding Functionality to Restore Card State on Page Render

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,6 +1,7 @@
 import ViewMoreLessButton from '../components/ViewMoreLessButton'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ReactNode } from 'react'
+import { z } from 'zod'
 
 interface CardProps {
   cardTitle: string
@@ -20,11 +21,49 @@ const Card = ({
   children,
 }: CardProps) => {
   const [isOpen, setIsOpen] = useState(false)
+  const CardState = z
+    .string()
+    .toLowerCase()
+    .transform((x) => x === 'true')
+    .pipe(z.boolean())
+  let reactDevBufferSet = false
+
+  /**
+   * init Effect
+   *
+   * In dev mode (npm run dev) React will prerender and render
+   * useEffects on page. This renders the page twice in dev mode,
+   * which erases the state.
+   *
+   * The reactDevBufferSet ensures it will only trigger once.
+   *
+   * This doesn't occur outside of dev.
+   *
+   * TODO: Moving the state out of the individual Cards and into
+   * a unified state/context may fix this this load issue.
+   */
+  useEffect(() => {
+    if (!reactDevBufferSet) {
+      reactDevBufferSet = true // eslint-disable-line
+      if (programUniqueId !== undefined) {
+        const sessionItem = sessionStorage.getItem(programUniqueId)
+
+        setIsOpen(sessionItem !== null ? CardState.parse(sessionItem) : false)
+      }
+    }
+  }, [])
+
+  // on change Effect
+  useEffect(() => {
+    if (programUniqueId !== undefined) {
+      sessionStorage.setItem(programUniqueId, String(isOpen))
+    }
+  }, [isOpen, programUniqueId])
 
   return (
-    <div className="border rounded border-gray-300 shadow my-6" data-cy="cards">
+    <div className="my-6 rounded border border-gray-300 shadow" data-cy="cards">
       <h2
-        className="py-4 md:py-8 md:mt-2 px-3 sm:px-8 md:px-15 text-4xl font-display font-bold text-gray-darker"
+        className="px-3 py-4 font-display text-4xl font-bold text-gray-darker sm:px-8 md:mt-2 md:px-15 md:py-8"
         data-cy="cardtitle"
       >
         {cardTitle}
@@ -40,7 +79,7 @@ const Card = ({
         ariaExpanded={isOpen}
         icon={isOpen}
         caption={viewMoreLessCaption}
-        className="pb-6 md:pb-8 md:pt-4 px-3 sm:px-8 md:px-15 w-full"
+        className="w-full px-3 pb-6 sm:px-8 md:px-15 md:pb-8 md:pt-4"
         acronym={acronym}
         refPageAA={refPageAA}
         ariaLabel={`${cardTitle} - ${viewMoreLessCaption}`}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "react-idle-timer": "^5.7.2",
         "react-modal": "^3.16.1",
         "release-please": "^15.13.0",
-        "yup": "^1.3.3"
+        "yup": "^1.3.3",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@babel/preset-react": "^7.23.3",
@@ -18232,6 +18233,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "react-idle-timer": "^5.7.2",
     "react-modal": "^3.16.1",
     "release-please": "^15.13.0",
-    "yup": "^1.3.3"
+    "yup": "^1.3.3",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.23.3",


### PR DESCRIPTION
## [ADO-159093](https://dev.azure.com/VP-BD/DECD/_workitems/edit/159093)

Fixed AB#

### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary
feat: added ability for card states on the dashboard page to be stored to, and restored from, session.

### Description of proposed changes:

### What to test for/How to test
run locally, open some cards on the dashboard then refresh your page. The cards should remain open

### Additional Notes
I leveraged zod to handle the boolean parsing and to play around with. I am looking into how to swap out yup for zod in other areas, but that's a separate ticket.
