### PR TITLE
OAuth Cookie Adjustments (for cookies too large issue)

### DIFF
--- a/helm/charts/secure-client-hub/templates/deployment.yaml
+++ b/helm/charts/secure-client-hub/templates/deployment.yaml
@@ -100,9 +100,6 @@ spec:
             {{- if .Values.oauth.args.sessionCookieMinimal }}
             - --session-cookie-minimal={{ .Values.oauth.args.sessionCookieMinimal }}
             {{- end }}
-            {{- if .Values.oauth.args.scope }}
-            - --scope={{ range $i, $value := .Values.oauth.args.scope }}{{ if ne $i 0 }},{{ end }}{{ $value | quote }}{{ end }}
-            {{- end }}
           name: oauth-proxy
           image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
           imagePullPolicy: Always

--- a/helm/charts/secure-client-hub/templates/deployment.yaml
+++ b/helm/charts/secure-client-hub/templates/deployment.yaml
@@ -97,6 +97,12 @@ spec:
             - --oidc-issuer-url={{ .Values.oauth.args.oidcIssuerURL }}
             - --skip-jwt-bearer-tokens={{ .Values.oauth.args.skipJWTBearerTokens }}
             - --skip-provider-button={{ .Values.oauth.args.skipProviderButton  }}
+            {{- if .Values.oauth.args.sessionCookieMinimal }}
+            - --session-cookie-minimal={{ .Values.oauth.args.sessionCookieMinimal }}
+            {{- end }}
+            {{- if .Values.oauth.args.scope }}
+            - --scope={{ range $i, $value := .Values.oauth.args.scope }}{{ if ne $i 0 }},{{ end }}{{ $value | quote }}{{ end }}
+            {{- end }}
           name: oauth-proxy
           image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
           imagePullPolicy: Always

--- a/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
@@ -117,7 +117,7 @@ ingress:
     enabled: true
     annotations: 
       kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/proxy-buffer-size: {{ env "PROXY_BUFFER_SIZE" | default "8k" }}
+      nginx.ingress.kubernetes.io/proxy-buffer-size: {{ env "OAUTH_PROXY_BUFFER_SIZE" | default "8k" }}
       nginx.ingress.kubernetes.io/ssl-redirect: 'true'
     tls:
       - hosts:
@@ -208,7 +208,7 @@ oauth:
     oidcIssuerURL: https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0
     skipJWTBearerTokens: true
     skipProviderButton: false
-    {{- if env "OAUTH_SESSION_COOKIE" }}
+    {{- if env "OAUTH_SESSION_COOKIE_MINIMAL" }}
     sessionCookieMinimal: true
     {{- end }}
   extraEnv:

--- a/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
@@ -211,11 +211,6 @@ oauth:
     {{- if env "OAUTH_SESSION_COOKIE" }}
     sessionCookieMinimal: true
     {{- end }}
-    {{- if env "OAUTH_SCOPE" }}
-    scope:
-      - "openid"
-      - "email"
-    {{- end }}
   extraEnv:
     - name: OAUTH2_PROXY_CLIENT_SECRET
       valueFrom:

--- a/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
@@ -208,10 +208,14 @@ oauth:
     oidcIssuerURL: https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0
     skipJWTBearerTokens: true
     skipProviderButton: false
+    {{- if env "OAUTH_SESSION_COOKIE" }}
     sessionCookieMinimal: true
+    {{- end }}
+    {{- if env "OAUTH_SCOPE" }}
     scope:
       - "openid"
       - "email"
+    {{- end }}
   extraEnv:
     - name: OAUTH2_PROXY_CLIENT_SECRET
       valueFrom:

--- a/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
@@ -117,7 +117,7 @@ ingress:
     enabled: true
     annotations: 
       kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+      nginx.ingress.kubernetes.io/proxy-buffer-size: {{ env "PROXY_BUFFER_SIZE" | default "8k" }}
       nginx.ingress.kubernetes.io/ssl-redirect: 'true'
     tls:
       - hosts:
@@ -208,6 +208,10 @@ oauth:
     oidcIssuerURL: https://login.microsoftonline.com/9ed55846-8a81-4246-acd8-b1a01abfc0d1/v2.0
     skipJWTBearerTokens: true
     skipProviderButton: false
+    sessionCookieMinimal: true
+    scope:
+      - "openid"
+      - "email"
   extraEnv:
     - name: OAUTH2_PROXY_CLIENT_SECRET
       valueFrom:


### PR DESCRIPTION
### Changelog 
fix: shrinking the oauth proxy cookie

### Description of proposed changes:
Allows the buffer size to be set by env var
Allows the activation of the session minimal cookie setting

The size of the cookie with the minimal setting goes from around 3400k~ to 340k~.

### What to test for/How to test
If the OAUTH_PROXY_BUFFER_SIZE env variable value is changed, it should be reflected in the post pipeline pod.
If the OAUTH_SESSION_COOKIE_MINIMAL env variable is set to true, the setting should show up in the oauth deployment

### Additional Notes
