### PR TITLE
add analytics to breadcrumbs

### DIFF
--- a/__tests__/components/Breadcrumb.test.js
+++ b/__tests__/components/Breadcrumb.test.js
@@ -21,6 +21,7 @@ describe('BreadCrumb', () => {
       <Breadcrumb
         id="breadcrumbID"
         items={[{ text: 'Canada.ca', link: '/' }]}
+        refPageAA='dashboard'
       />,
     )
     expect(primary).toBeTruthy()
@@ -36,6 +37,7 @@ describe('BreadCrumb', () => {
           { text: 'Link2', link: '/' },
           { text: 'Link3', link: '/' },
         ]}
+        refPageAA='dashboard'
       />,
     )
     expect(withItems).toBeTruthy()
@@ -52,6 +54,7 @@ describe('BreadCrumb', () => {
           { text: 'Max length of breadcrumb 28', link: '/' },
           { text: 'Link3', link: '/' },
         ]}
+        refPageAA='dashboard'
       />,
     )
     expect(withItemsWithLongText).toBeTruthy()
@@ -62,6 +65,7 @@ describe('BreadCrumb', () => {
       <Breadcrumb
         id="breadcrumbID"
         items={[{ text: 'Canada.ca', link: '/' }]}
+      refPageAA='dashboard'
       />,
     )
     const results = await axe(container)

--- a/__tests__/components/Header.test.js
+++ b/__tests__/components/Header.test.js
@@ -62,6 +62,7 @@ describe('Header', () => {
       { text: 'Max length of breadcrumb 28', link: '/' },
       { text: 'Link3', link: '/' },
     ],
+    refPageAA: 'dashboard'
   }
   test('renders Header component with default props', () => {
     render(<Header {...defaultProps} />)

--- a/components/Breadcrumb.tsx
+++ b/components/Breadcrumb.tsx
@@ -10,9 +10,10 @@ export interface BreadcrumbItem {
 export interface BreadcrumbProps {
   id?: string
   items?: BreadcrumbItem[]
+  refPageAA: string
 }
 
-const Breadcrumb = ({ id, items }: BreadcrumbProps) => {
+const Breadcrumb = ({ id, items, refPageAA }: BreadcrumbProps) => {
   return (
     <nav className="py-6" aria-label="Breadcrumb-Fil d’ariane" id={id}>
       <ul className="block font-body text-base leading-[23px] text-deep-blue-dark">
@@ -32,6 +33,7 @@ const Breadcrumb = ({ id, items }: BreadcrumbProps) => {
                     data-cy={'breadcrumb-' + item.text}
                     href={item.link}
                     className="font-body underline hover:text-blue-hover focus:text-blue-hover"
+                    data-gc-analytics-customclick={`${refPageAA}:${item.text}`}
                   >
                     {item.text}
                   </Link>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -45,6 +45,7 @@ interface HeaderProps {
   menuProps: MenuProps
   topnavProps: TopNavProps
   breadCrumbItems: BreadcrumbItemProps[]
+  refPageAA: string
   dataGcAnalyticsCustomClickInstitutionVariable: string
   dataGcAnalyticsCustomClickMenuVariable: string
 }
@@ -55,6 +56,7 @@ const Header = ({
   linkPath,
   menuProps,
   breadCrumbItems,
+  refPageAA,
   topnavProps,
   dataGcAnalyticsCustomClickInstitutionVariable,
   dataGcAnalyticsCustomClickMenuVariable,
@@ -117,7 +119,9 @@ const Header = ({
           dataGcAnalyticsCustomClick={dataGcAnalyticsCustomClickMenuVariable}
         />
         <div className="sch-container">
-          <Breadcrumb items={breadCrumbItems} />
+          <Breadcrumb items={breadCrumbItems}
+            refPageAA={refPageAA}
+        />
         </div>
       </header>
     </div>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -123,6 +123,7 @@ export default function Layout(props) {
         breadCrumbItems={
           props.breadCrumbItems ? props.breadCrumbItems : defaultBreadcrumbs
         }
+        refPageAA={props.refPageAA}
         topnavProps={{
           skipToMainPath: '#mainContent',
           skipToAboutPath: '#page-footer',


### PR DESCRIPTION
Adding analytics tag data-gc to Breadcrumbs. I can run the app fine with my changes, but am still unable to see anything relevant under Network - not sure if I'm missing a setting under .env.local.

https://dev.azure.com/VP-BD/DECD/_boards/board/t/Secure%20Client%20Hub/Stories%20and%20Activities
