### PR TITLE
Update dashboard mapper to include alternate stream 3 links

### DIFF
--- a/graphql/mappers/my-dashboard.ts
+++ b/graphql/mappers/my-dashboard.ts
@@ -70,6 +70,8 @@ interface GetSchMyDashboardV2 {
                 schURLType?: string
                 scDestinationURLEn: string
                 scDestinationURLFr: string
+                scDestinationURL3En?: string | null
+                scDestinationURL3Fr?: string | null
                 scIconCSS: string
                 schBetaPopUp: boolean
               }>
@@ -135,7 +137,13 @@ export async function getMyDashboardContent() {
                     id: item.scId,
                     title: item.scLinkTextEn,
                     areaLabel: item.scLinkTextAssistiveEn,
-                    link: buildLink(item.schURLType, item.scDestinationURLEn),
+                    link: buildLink(
+                      item.schURLType,
+                      process.env.ENVIRONMENT === 'development' &&
+                        item.scDestinationURL3En !== null
+                        ? item.scDestinationURL3En
+                        : item.scDestinationURLEn,
+                    ),
                     icon: item.scIconCSS,
                     betaPopUp: item.schBetaPopUp,
                   }
@@ -189,7 +197,13 @@ export async function getMyDashboardContent() {
                     id: item.scId,
                     title: item.scLinkTextFr,
                     areaLabel: item.scLinkTextAssistiveFr,
-                    link: buildLink(item.schURLType, item.scDestinationURLFr),
+                    link: buildLink(
+                      item.schURLType,
+                      process.env.ENVIRONMENT === 'development' &&
+                        item.scDestinationURL3Fr !== null
+                        ? item.scDestinationURL3Fr
+                        : item.scDestinationURLFr,
+                    ),
                     icon: item.scIconCSS,
                     betaPopUp: item.schBetaPopUp,
                   }


### PR DESCRIPTION
## [ADO-193547](https://dev.azure.com/VP-BD/DECD/_workitems/edit/193547)

Fixed [AB#193547](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/193547)

### Changelog
- feat:update dashboard mapper to support alternate links in dev

### Description of proposed changes:
This PR updates the dashboard mapper to support alternate links where they exist for stream 3. This will be expanded on at a later date to include the other streams when that functionality become available to us.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. On the dashboard, ensure that when hovering over MEIIO links that the link contains `meiio-mrad-II`
