### PR TITLE
added info message to dashboard page

### DIFF
--- a/__tests__/components/InfoMessage.test.js
+++ b/__tests__/components/InfoMessage.test.js
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import InfoMessage from '../../components/InfoMessage'
+
+expect.extend(toHaveNoViolations)
+
+describe('InfoMessage', () => {
+  it('renders InfoMessage', () => {
+    render(
+      <InfoMessage
+        data-testid={'label'}
+        messageText={'messageText'}
+        messageLinkText={'messageLinkText'}
+        icon={'arrow-up-right-from-square'}
+      ></InfoMessage>,
+    )
+    const label = screen.getAllByTestId('label')
+    const messageText = screen.getByText('messageText')
+    const messageLinkText = screen.getByText('messageLinkText')
+
+    expect.arrayContaining(label)
+    expect(messageText).toBeInTheDocument()
+    expect(messageLinkText).toBeInTheDocument()
+  })
+
+  it('has no a11y viollations', async () => {
+    const { container } = render(
+      <InfoMessage
+        label={'label'}
+        messageText={'messageText'}
+        messageLinkText={'messageLinkText'}
+        messageLinkHref={'messageLinkHref'}
+        icon={'arrow-up-right-from-square'}
+      ></InfoMessage>,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/components/InfoMessage.tsx
+++ b/components/InfoMessage.tsx
@@ -1,0 +1,75 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { icon as loadIcon } from '../lib/loadIcons'
+
+interface InfoMessageProps {
+  label: string
+  messageText: string
+  messageLinkText: string
+  messageLinkHref: string
+  locale: string
+  icon?: string
+  refPageAA: string
+}
+
+const InfoMessage = ({
+  locale,
+  label,
+  messageText,
+  messageLinkText,
+  messageLinkHref,
+  icon,
+  refPageAA,
+}: InfoMessageProps) => {
+  return (
+    <div
+      className="sch-container mt-6 border border-[#E3E3E3] bg-gray-lightest py-4"
+      data-cy="info-message"
+      aria-label={`${label}`}
+    >
+      <div className="flex flex-row">
+        <span
+          className="hidden max-h-10 items-center border-l-[6px] border-brighter-blue-dark bg-[#d7faff] p-2 text-xl font-bold sm:flex"
+          data-testid="label"
+        >
+          {label}
+        </span>
+        <div
+          className="text-xl text-gray-darker sm:pl-6"
+          data-cy="info-message-text"
+        >
+          <span
+            className="mr-3 inline-flex max-h-8 items-center border-l-[6px] border-brighter-blue-dark bg-[#d7faff] p-2 font-bold sm:hidden"
+            data-testid="label"
+          >
+            {label}
+          </span>
+
+          {messageText}
+          <a
+            data-cy="sclabs-page-link"
+            href={messageLinkHref}
+            className="inline-block text-xl text-deep-blue-60d hover:text-blue-hover focus:text-blue-hover focus:underline"
+            target={'_blank'}
+            rel={'noopener noreferrer'}
+            data-gc-analytics-customclick={`${refPageAA}:${messageLinkText} link`}
+            aria-label={` ${messageLinkText} - ${
+              messageLinkText
+                ? locale === 'fr'
+                  ? "S'ouvre dans un nouvel onglet"
+                  : 'Opens in a new tab'
+                : "S'ouvre dans un nouvel onglet"
+            }`}
+          >
+            <span className="mr-2 underline">{messageLinkText}</span>
+            <FontAwesomeIcon
+              width="14"
+              icon={loadIcon[icon as keyof typeof FontAwesomeIcon]}
+            ></FontAwesomeIcon>
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default InfoMessage

--- a/cypress/e2e/dashboard.cy.js
+++ b/cypress/e2e/dashboard.cy.js
@@ -35,13 +35,42 @@ describe('Validate dashboard page', () => {
     cy.get('[data-testid="bannerButton"]').should('be.visible')
   })
 
-  it('Validate 5 Cards (EI,CPP,OAS,SIN,CAL) and Card titles are Visible', () => {
-    cy.get('[data-testid="myDashboardContent-test"]')
-      .children('[data-cy="cards"]')
-      .should('be.visible')
-      .and('have.length', 6)
-    cy.get('[data-cy="cardtitle"]').should('be.visible').and('have.length', 6)
+  it('Validate info message is present on Dashboard EN', () => {
+    cy.get('[data-cy="info-message"]').should('be.visible').and('include.text', 'New')
+    cy.get('[data-cy="info-message-text"]').should('be.visible')
+    cy.get('[data-cy="sclabs-page-link"]').should('be.visible')
   })
+
+  it('Validate info message is present on Dashboard FR', () => {
+    cy.changeLang().should('have.text', 'English')
+    cy.location('pathname').should('include', '/fr/mon-tableau-de-bord')
+    cy.get('[data-cy="info-message"]').should('be.visible').and('include.text', 'Nouveau')
+    cy.get('[data-cy="info-message-text"]').should('be.visible')
+    cy.get('[data-cy="sclabs-page-link"]').should('be.visible')
+  })
+ 
+
+  it('Validate 5 Cards (EI,CPP,OAS,SIN,CAL) +2 cards for (CPCD and OAS) and Card titles are Visible', () => {
+    const cardTitles = [
+      'Canadian Dental Care Plan',
+      'Employment Insurance',
+      'Canada Pension Plan',
+      'Old Age Security',
+      'Social Insurance Number',
+      'Canada Apprentice Loan',
+      'Old Age Security',
+    ]
+    cy.wrap(cardTitles).each((cardTitle) => {
+      // Find the card with the specific title
+      cy.contains('[data-cy="cards"]', cardTitle).as('currentCard')
+      // Check the card title
+      cy.get('@currentCard').should('contain', cardTitle)
+  })
+  cy.get('[data-testid="myDashboardContent-test"]')
+  .children('[data-cy="cards"]')
+  .should('be.visible')
+  .and('have.length', 6)
+})
 
   it('validate the "My dashboard" page doesnt have breadcrumbs', () => {
     cy.get("[class='sch-container'] >nav>ul>li>a").should('not.exist')

--- a/locales/en.js
+++ b/locales/en.js
@@ -25,7 +25,15 @@ export default {
     title: 'My dashboard',
     profile: 'Profile',
   },
-
+  //
+  //Dashboard info message
+  dashboardInfo: {
+    label: 'New',
+    messageText:
+      "Your MSCA account now has a Dashboard view! If you'd like to learn more about our changes, please visit our ",
+    messageLinkHref: 'https://alpha.service.canada.ca/en/projects/dashboard',
+    messageLinkText: ' Service Canada Labs page',
+  },
   //User testing with beta banner this is to be deleted after UT
   betaBanner: {
     bannerBoldText: 'Beta version:',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -23,6 +23,16 @@ export default {
     title: 'Mon tableau de bord',
     profile: 'Profil',
   },
+  //
+  //Dashboard info message
+  dashboardInfo: {
+    label: 'Nouveau',
+    messageText:
+      'Mon dossier Service Canada a une nouvelle apparence. Pour en savoir plus, veuillez consulter les ',
+    messageLinkHref:
+      'https://alpha.service.canada.ca/fr/projets/tableau-de-bord',
+    messageLinkText: ' Laboratoires de Service Canada',
+  },
   //User testing with beta banner this is to be deleted after UT
   betaBanner: {
     bannerBoldText: 'Version bêta :',

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -4,7 +4,7 @@ import fr from '../locales/fr'
 import Card from '../components/Card'
 import Heading from '../components/Heading'
 import ContextualAlert from '../components/ContextualAlert'
-
+import InfoMessage from '../components/InfoMessage'
 import { getMyDashboardContent } from '../graphql/mappers/my-dashboard'
 import { getBetaBannerContent } from '../graphql/mappers/beta-banner-opt-out'
 import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
@@ -59,6 +59,17 @@ export default function MyDashboard(props) {
       data-testid="myDashboardContent-test"
     >
       <Heading id="my-dashboard-heading" title={props.content.heading} />
+
+      <InfoMessage
+        id="dashboard-info-message"
+        label={t.dashboardInfo.label}
+        messageText={t.dashboardInfo.messageText}
+        messageLinkText={t.dashboardInfo.messageLinkText}
+        messageLinkHref={t.dashboardInfo.messageLinkHref}
+        icon="arrow-up-right-from-square"
+        refPageAA={`${props.aaPrefix}`}
+        locale={props.locale}
+      />
 
       {props.content.pageAlerts.map((alert, index) => {
         const alertType = alert.type[0].split('/').pop()


### PR DESCRIPTION
## [ADO-194170](https://dev.azure.com/VP-BD/DECD/_workitems/edit/194170)

 AB#194170

### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary

### Description of proposed changes:
Added new info message section to the dashboard page
Has a 'New' label, text and a link to SCLabs.  (content is local)

### What to test for/How to test
Dashboard page has the info message on it. 
It matches the mockups in the task for desktop and mobile

### Additional Notes
the mockup doesn't show the opens in a new tab icon but it was requested after so it was added.
