### PR TITLE
Temporarily update dashboard mapper for Curam test deployment

### DIFF
--- a/graphql/mappers/my-dashboard.ts
+++ b/graphql/mappers/my-dashboard.ts
@@ -137,13 +137,8 @@ export async function getMyDashboardContent() {
                     id: item.scId,
                     title: item.scLinkTextEn,
                     areaLabel: item.scLinkTextAssistiveEn,
-                    link: buildLink(
-                      item.schURLType,
-                      process.env.ENVIRONMENT === 'development' &&
-                        item.scDestinationURL3En !== null
-                        ? item.scDestinationURL3En
-                        : item.scDestinationURLEn,
-                    ),
+                    //TO-DO: Set destination URL based on a new environment variable for stream
+                    link: buildLink(item.schURLType, item.scDestinationURLEn),
                     icon: item.scIconCSS,
                     betaPopUp: item.schBetaPopUp,
                   }
@@ -197,13 +192,8 @@ export async function getMyDashboardContent() {
                     id: item.scId,
                     title: item.scLinkTextFr,
                     areaLabel: item.scLinkTextAssistiveFr,
-                    link: buildLink(
-                      item.schURLType,
-                      process.env.ENVIRONMENT === 'development' &&
-                        item.scDestinationURL3Fr !== null
-                        ? item.scDestinationURL3Fr
-                        : item.scDestinationURLFr,
-                    ),
+                    //TO-DO: Set destination URL based on a new environment variable for stream
+                    link: buildLink(item.schURLType, item.scDestinationURLFr),
                     icon: item.scIconCSS,
                     betaPopUp: item.schBetaPopUp,
                   }


### PR DESCRIPTION
### Changelog
fix:Temporarily update dashboard mapper to point to correct links

### Description of proposed changes:
The latest update to the mapper on dev was to specifically show stream 3 MEIIO links if the `environment` env was set to `development`. This will suffice for our testing on stream 3 but not for other streams since the alternate MEIIO links are exclusive to stream 3. This PR temporarily reverts the change to the mapper so that the old links are used (which matches prod and the other streams) until we update our mapper to account for all streams.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to dashboard and ensure the MEIIO links are being shown correctly.
