### PR TITLE
Update middleware to account for redirect after MSCA login

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -19,6 +19,15 @@ export async function middleware(req: NextRequest) {
     return
   }
 
+  //Redirect from splash page if Lang parameter is supplied when redirecting from MSCA
+  if (pathname === '/&Lang=fra') {
+    return NextResponse.redirect(new URL(`/fr/mon-tableau-de-bord`, url))
+  }
+  if (pathname === '/&Lang=eng') {
+    return NextResponse.redirect(new URL(`/en/my-dashboard`, url))
+  }
+
+  //Redirect rule that makes English appear as the default language instead of und
   if (locale === 'und' && !pathname.endsWith('/')) {
     return NextResponse.redirect(new URL(`/en${pathname}`, url))
   }


### PR DESCRIPTION
## [ADO-192855](https://dev.azure.com/VP-BD/DECD/_workitems/edit/192855)

Fixed [AB#192855](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/192855)

### Changelog
fix: Update middleware to handle MSCA redirect

### Description of proposed changes:
This PR updates our middleware to handle the redirect from MSCA after logging in. Since the recent changes to the ARB in dev, Stream 3 has been redirecting to `/&Lang=eng` or `/&Lang=fra` depending on the language selected before redirecting. This PR adds a couple rules at the top of the stack in our middleware that checks for this and redirects to the respective dashboard page.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Try navigating to `/&Lang=eng` (casing is important here as the parameter passed to us is uppercase Lang). You should be redirected to the English dashboard
4. Try navigating to `/&Lang=fra`. You should be redirected to the French dashboard

### Additional Notes
In the future we should look into leveraging the NEXT_LOCALE cookie to handle locale redirection. More info can be found here: https://nextjs.org/docs/pages/building-your-application/routing/internationalization#leveraging-the-next_locale-cookie