### PR TITLE
Hotfix to update validation logic on prod due to RAOIDC bug

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { useState, cloneElement } from 'react'
+import { useState, useCallback, useMemo, useEffect, cloneElement } from 'react'
 import Header from './Header'
 import Footer from './Footer'
 import MetaData from './MetaData'
@@ -8,10 +8,15 @@ import en from '../locales/en'
 import fr from '../locales/fr'
 import MultiModal from './MultiModal'
 import { lato, notoSans } from '../utils/fonts'
+import throttle from 'lodash.throttle'
+import { useRouter } from 'next/router'
+import { signOut } from 'next-auth/react'
 
 export default function Layout(props) {
   const display = props.display ?? {}
   const t = props.locale === 'en' ? en : fr
+  const [response, setResponse] = useState()
+  const router = useRouter()
   const defaultBreadcrumbs = []
   const contactLink =
     props.locale === 'en' ? '/en/contact-us' : '/fr/contactez-nous'
@@ -40,6 +45,46 @@ export default function Layout(props) {
       }
     })
   }
+
+  const validationResponse = useCallback(
+    async () => setResponse(await fetch('/api/refresh-msca')),
+    [],
+  )
+  //Event listener for click events that revalidates MSCA session, throttled using lodash to only trigger every 1 minute
+  const throttledOnClickEvent = useMemo(
+    () => throttle(validationResponse, 60000, { trailing: false }),
+    [validationResponse],
+  )
+  //Event listener for visibility change events that revalidates MSCA session, throttled using lodash to only trigger every 15 seconds
+  const throttledVisiblityChangeEvent = useMemo(
+    () => throttle(validationResponse, 15000, { trailing: false }),
+    [validationResponse],
+  )
+
+  //If session is valid, add event listeners to check for valid sessions on click and visibility change events
+  useEffect(() => {
+    window.addEventListener('visibilitychange', throttledVisiblityChangeEvent)
+    window.addEventListener('click', throttledOnClickEvent)
+    //If validateSession call indicates an invalid MSCA session, redirect to logout
+    if (response?.status === 401) {
+      signOut()
+      router.push(`/${props.locale}/auth/login`)
+    }
+    //Remove event on unmount to prevent a memory leak with the cleanup
+    return () => {
+      window.removeEventListener('click', throttledOnClickEvent)
+      window.removeEventListener(
+        'visiblitychange',
+        throttledVisiblityChangeEvent,
+      )
+    }
+  }, [
+    throttledOnClickEvent,
+    throttledVisiblityChangeEvent,
+    response,
+    router,
+    props.locale,
+  ])
 
   return (
     <>

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -36,14 +36,14 @@ export async function ValidateSession(clientId, sharedSessionId) {
                 host: 'localhost',
                 port: 3128,
               },
-            }
+            },
           )
           .then((response) => response)
           .catch((error) => logger.error(error))
       : await axios
           .get(
             process.env.AUTH_ECAS_REFRESH_ENDPOINT +
-              `?client_id=${clientId}&shared_session_id=${sharedSessionId}`
+              `?client_id=${clientId}&shared_session_id=${sharedSessionId}`,
           )
           .then((response) => response)
           .catch((error) => logger.error(error))
@@ -54,7 +54,7 @@ export async function ValidateSession(clientId, sharedSessionId) {
     : logger.trace('Something went wrong renewing the session')
 
   //return response to handler
-  return getResponse.data
+  return getResponse?.data ?? false
 }
 
 export async function getLogoutURL(req, session) {

--- a/pages/contact-us/[id].tsx
+++ b/pages/contact-us/[id].tsx
@@ -1,7 +1,6 @@
-import { Fragment, useEffect, useCallback, useMemo, useState } from 'react'
+import { Fragment } from 'react'
 import TableContents from '../../components/TableContents'
 import Heading from '../../components/Heading'
-
 import { ContactSection } from '../../components/contact/ContactSection'
 import { ContactProvince } from '../../components/contact/ContactProvince'
 import { getBetaBannerContent } from '../../graphql/mappers/beta-banner-opt-out'
@@ -12,12 +11,16 @@ import {
   GetContactUsPageReturnType,
   getContactUsPage,
 } from '../../graphql/mappers/contact-us-pages-dynamic'
-import { AuthIsDisabled, AuthIsValid, Redirect } from '../../lib/auth'
+import {
+  AuthIsDisabled,
+  AuthIsValid,
+  Redirect,
+  ValidateSession,
+} from '../../lib/auth'
 import { authOptions } from '../api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
-import throttle from 'lodash.throttle'
-import { useRouter } from 'next/router'
 import { GetServerSideProps } from 'next'
+import { getToken } from 'next-auth/jwt'
 
 interface Data {
   title: string
@@ -41,31 +44,6 @@ interface ContactUsPageProps {
 
 const ContactUsPage = (props: ContactUsPageProps) => {
   /* istanbul ignore next */
-
-  const [response, setResponse] = useState<Response | undefined>()
-  const router = useRouter()
-
-  //Event listener for click events that revalidates MSCA session, throttled using lodash to only trigger every 1 minute
-  const onClickEvent = useCallback(
-    async () => setResponse(await fetch('/api/refresh-msca')),
-    [],
-  )
-  const throttledOnClickEvent = useMemo(() => {
-    return throttle(onClickEvent, 60000, { trailing: false })
-  }, [onClickEvent])
-
-  useEffect(() => {
-    window.addEventListener('click', throttledOnClickEvent)
-    //If validateSession call indicates an invalid MSCA session, redirect to logout
-    if (response?.status === 401) {
-      router.push(`/${props.locale}/auth/logout`)
-    }
-    //Remove event on unmount to prevent a memory leak with the cleanup
-    return () => {
-      window.removeEventListener('click', throttledOnClickEvent)
-    }
-  }, [throttledOnClickEvent, response, router, props.locale])
-
   return (
     <div
       id="homeContent"
@@ -111,9 +89,37 @@ const ContactUsPage = (props: ContactUsPageProps) => {
 
 export const getServerSideProps = (async ({ req, res, locale, params }) => {
   const session = await getServerSession(req, res, authOptions)
+  const token = await getToken({ req })
 
-  if (!AuthIsDisabled() && !(await AuthIsValid(req, session))) {
+  if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
+
+  //If Next-Auth session is valid, check to see if ECAS session is valid and clear cookies and redirect to login if not
+  if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
+    const sessionValid = await ValidateSession(
+      process.env.CLIENT_ID,
+      token?.sub,
+    )
+    if (!sessionValid) {
+      // Clear all session cookies
+      const isSecure = req.headers['x-forwarded-proto'] === 'https'
+      const cookiePrefix = `${isSecure ? '__Secure-' : ''}next-auth.session-token`
+      const cookies = []
+      for (const cookie of Object.keys(req.cookies)) {
+        if (cookie.startsWith(cookiePrefix)) {
+          cookies.push(
+            `${cookie}=deleted; Max-Age=0; path=/ ${isSecure ? '; Secure ' : ''}`,
+          )
+        }
+      }
+      res.setHeader('Set-Cookie', cookies)
+      return {
+        redirect: {
+          destination: `/${locale}/auth/login`,
+          permanent: false,
+        },
+      }
+    }
   }
 
   const id = params?.id

--- a/pages/contact-us/index.tsx
+++ b/pages/contact-us/index.tsx
@@ -8,14 +8,17 @@ import {
 } from '../../graphql/mappers/contact-us'
 import { getBetaBannerContent } from '../../graphql/mappers/beta-banner-opt-out'
 import { getBetaPopupExitContent } from '../../graphql/mappers/beta-popup-exit'
-import { AuthIsDisabled, AuthIsValid, Redirect } from '../../lib/auth'
+import {
+  AuthIsDisabled,
+  AuthIsValid,
+  Redirect,
+  ValidateSession,
+} from '../../lib/auth'
 import { authOptions } from '../api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
-import { useEffect, useCallback, useMemo, useState } from 'react'
-import throttle from 'lodash.throttle'
-import { useRouter } from 'next/router'
 import { GetServerSideProps } from 'next'
 import { BreadcrumbItem } from '../../components/Breadcrumb'
+import { getToken } from 'next-auth/jwt'
 
 interface Data {
   title: string
@@ -42,30 +45,6 @@ interface ContactLandingProps {
 }
 
 const ContactLanding = (props: ContactLandingProps) => {
-  const [response, setResponse] = useState<Response | undefined>()
-  const router = useRouter()
-
-  //Event listener for click events that revalidates MSCA session, throttled using lodash to only trigger every 1 minute
-  const onClickEvent = useCallback(
-    async () => setResponse(await fetch('/api/refresh-msca')),
-    [],
-  )
-  const throttledOnClickEvent = useMemo(
-    () => throttle(onClickEvent, 60000, { trailing: false }),
-    [onClickEvent],
-  )
-
-  useEffect(() => {
-    window.addEventListener('click', throttledOnClickEvent)
-    if (response?.status === 401) {
-      router.push(`/${props.locale}/auth/logout`)
-    }
-    //Remove event on unmount to prevent a memory leak with the cleanup
-    return () => {
-      window.removeEventListener('click', throttledOnClickEvent)
-    }
-  }, [throttledOnClickEvent, response, router, props.locale])
-
   return (
     <div id="contactContent" data-testid="contactContent-test">
       <Heading id="contact-us-heading" title={props.content.heading ?? ''} />
@@ -100,9 +79,37 @@ const ContactLanding = (props: ContactLandingProps) => {
 }
 export const getServerSideProps = (async ({ req, res, locale }) => {
   const session = await getServerSession(req, res, authOptions)
+  const token = await getToken({ req })
 
-  if (!AuthIsDisabled() && !(await AuthIsValid(req, session))) {
+  if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
+
+  //If Next-Auth session is valid, check to see if ECAS session is valid and clear cookies and redirect to login if not
+  if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
+    const sessionValid = await ValidateSession(
+      process.env.CLIENT_ID,
+      token?.sub,
+    )
+    if (!sessionValid) {
+      // Clear all session cookies
+      const isSecure = req.headers['x-forwarded-proto'] === 'https'
+      const cookiePrefix = `${isSecure ? '__Secure-' : ''}next-auth.session-token`
+      const cookies = []
+      for (const cookie of Object.keys(req.cookies)) {
+        if (cookie.startsWith(cookiePrefix)) {
+          cookies.push(
+            `${cookie}=deleted; Max-Age=0; path=/ ${isSecure ? '; Secure ' : ''}`,
+          )
+        }
+      }
+      res.setHeader('Set-Cookie', cookies)
+      return {
+        redirect: {
+          destination: `/${locale}/auth/login`,
+          permanent: false,
+        },
+      }
+    }
   }
 
   const content = await getContactUsContent()

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -1,4 +1,3 @@
-import { useEffect, useCallback, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import en from '../locales/en'
 import fr from '../locales/fr'
@@ -10,43 +9,23 @@ import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
 import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-page-not-available'
 import { getAuthModalsContent } from '../graphql/mappers/auth-modals'
 import { getLogger } from '../logging/log-util'
-import { AuthIsDisabled, AuthIsValid, Redirect } from '../lib/auth'
+import {
+  AuthIsDisabled,
+  AuthIsValid,
+  Redirect,
+  ValidateSession,
+} from '../lib/auth'
 import { authOptions } from '../pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
 import BenefitTasks from './../components/BenefitTasks'
 import MostReqTasks from './../components/MostReqTasks'
-import throttle from 'lodash.throttle'
 import { acronym } from '../lib/acronym'
 import ErrorPage from '../components/ErrorPage'
-import { useRouter } from 'next/router'
+import { getToken } from 'next-auth/jwt'
 
 export default function MyDashboard(props) {
   /* istanbul ignore next */
   const t = props.locale === 'en' ? en : fr
-  const [response, setResponse] = useState()
-  const router = useRouter()
-
-  //Event listener for click events that revalidates MSCA session, throttled using lodash to only trigger every 1 minute
-  const onClickEvent = useCallback(
-    async () => setResponse(await fetch('/api/refresh-msca')),
-    [],
-  )
-  const throttledOnClickEvent = useMemo(
-    () => throttle(onClickEvent, 60000, { trailing: false }),
-    [onClickEvent],
-  )
-
-  useEffect(() => {
-    window.addEventListener('click', throttledOnClickEvent)
-    //If validateSession call indicates an invalid MSCA session, redirect to logout
-    if (response?.status === 401) {
-      router.push(`/${props.locale}/auth/logout`)
-    }
-    //Remove event on unmount to prevent a memory leak with the cleanup
-    return () => {
-      window.removeEventListener('click', throttledOnClickEvent)
-    }
-  }, [throttledOnClickEvent, response, router, props.locale])
 
   const errorCode =
     props.content?.err ||
@@ -128,9 +107,38 @@ export default function MyDashboard(props) {
 
 export async function getServerSideProps({ req, res, locale }) {
   const session = await getServerSession(req, res, authOptions)
+  const token = await getToken({ req })
 
   if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
+
+  //If Next-Auth session is valid, check to see if ECAS session is valid and clear cookies and redirect to login if not
+  if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
+    const sessionValid = await ValidateSession(
+      process.env.CLIENT_ID,
+      token?.sub,
+    )
+    if (!sessionValid) {
+      // Clear all session cookies
+      const isSecure = req.headers['x-forwarded-proto'] === 'https'
+      const cookiePrefix = `${isSecure ? '__Secure-' : ''}next-auth.session-token`
+      const cookies = []
+      for (const cookie of Object.keys(req.cookies)) {
+        if (cookie.startsWith(cookiePrefix)) {
+          cookies.push(
+            `${cookie}=deleted; Max-Age=0; path=/ ${isSecure ? '; Secure ' : ''}`,
+          )
+        }
+      }
+      res.setHeader('Set-Cookie', cookies)
+      return {
+        redirect: {
+          destination: `/${locale}/auth/login`,
+          permanent: false,
+        },
+      }
+    }
+  }
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('my-dashboard')

--- a/pages/privacy-notice-terms-conditions.js
+++ b/pages/privacy-notice-terms-conditions.js
@@ -1,4 +1,3 @@
-import { useEffect, useCallback, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import Date from '../components/Date'
 import Heading from '../components/Heading'
@@ -9,7 +8,12 @@ import { getPrivacyConditionContent } from '../graphql/mappers/privacy-notice-te
 import { getBetaBannerContent } from '../graphql/mappers/beta-banner-opt-out'
 import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
 import { getLogger } from '../logging/log-util'
-import { AuthIsDisabled, AuthIsValid, Redirect } from '../lib/auth'
+import {
+  AuthIsDisabled,
+  AuthIsValid,
+  Redirect,
+  ValidateSession,
+} from '../lib/auth'
 import { authOptions } from '../pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
 import BackToButton from '../components/BackToButton'
@@ -17,36 +21,11 @@ import Markdown from 'markdown-to-jsx'
 import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-page-not-available'
 import { getAuthModalsContent } from '../graphql/mappers/auth-modals'
 import React from 'react'
-import throttle from 'lodash.throttle'
 import ErrorPage from '../components/ErrorPage'
-import { useRouter } from 'next/router'
+import { getToken } from 'next-auth/jwt'
 
 export default function PrivacyCondition(props) {
   const t = props.locale === 'en' ? en : fr
-  const [response, setResponse] = useState()
-  const router = useRouter()
-
-  //Event listener for click events that revalidates MSCA session, throttled using lodash to only trigger every 1 minute
-  const onClickEvent = useCallback(
-    async () => setResponse(await fetch('/api/refresh-msca')),
-    [],
-  )
-  const throttledOnClickEvent = useMemo(
-    () => throttle(onClickEvent, 60000, { trailing: false }),
-    [onClickEvent],
-  )
-
-  useEffect(() => {
-    window.addEventListener('click', throttledOnClickEvent)
-    //If validateSession call indicates an invalid MSCA session, redirect to logout
-    if (response?.status === 401) {
-      router.push(`/${props.locale}/auth/logout`)
-    }
-    //Remove event on unmount to prevent a memory leak with the cleanup
-    return () => {
-      window.removeEventListener('click', throttledOnClickEvent)
-    }
-  }, [throttledOnClickEvent, response, router, props.locale])
 
   const errorCode =
     props.content?.err ||
@@ -203,9 +182,38 @@ export default function PrivacyCondition(props) {
 
 export async function getServerSideProps({ req, res, locale }) {
   const session = await getServerSession(req, res, authOptions)
+  const token = await getToken({ req })
 
   if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
+
+  //If Next-Auth session is valid, check to see if ECAS session is valid and clear cookies and redirect to login if not
+  if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
+    const sessionValid = await ValidateSession(
+      process.env.CLIENT_ID,
+      token?.sub,
+    )
+    if (!sessionValid) {
+      // Clear all session cookies
+      const isSecure = req.headers['x-forwarded-proto'] === 'https'
+      const cookiePrefix = `${isSecure ? '__Secure-' : ''}next-auth.session-token`
+      const cookies = []
+      for (const cookie of Object.keys(req.cookies)) {
+        if (cookie.startsWith(cookiePrefix)) {
+          cookies.push(
+            `${cookie}=deleted; Max-Age=0; path=/ ${isSecure ? '; Secure ' : ''}`,
+          )
+        }
+      }
+      res.setHeader('Set-Cookie', cookies)
+      return {
+        redirect: {
+          destination: `/${locale}/auth/login`,
+          permanent: false,
+        },
+      }
+    }
+  }
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('privacy-notice-terms-and-conditions')

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -9,44 +9,23 @@ import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
 import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-page-not-available'
 import { getAuthModalsContent } from '../graphql/mappers/auth-modals'
 import { getLogger } from '../logging/log-util'
-import { AuthIsDisabled, AuthIsValid, Redirect } from '../lib/auth'
+import {
+  AuthIsDisabled,
+  AuthIsValid,
+  Redirect,
+  ValidateSession,
+} from '../lib/auth'
 import { authOptions } from '../pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
 import ProfileTasks from './../components/ProfileTasks'
 import React from 'react'
-import { useEffect, useCallback, useMemo, useState } from 'react'
-import throttle from 'lodash.throttle'
 import { acronym } from '../lib/acronym'
 import ErrorPage from '../components/ErrorPage'
-import { useRouter } from 'next/router'
+import { getToken } from 'next-auth/jwt'
 
 export default function Profile(props) {
   /* istanbul ignore next */
   const t = props.locale === 'en' ? en : fr
-  const [response, setResponse] = useState()
-  const router = useRouter()
-
-  //Event listener for click events that revalidates MSCA session, throttled using lodash to only trigger every 1 minute
-  const onClickEvent = useCallback(
-    async () => setResponse(await fetch('/api/refresh-msca')),
-    [],
-  )
-  const throttledOnClickEvent = useMemo(
-    () => throttle(onClickEvent, 60000, { trailing: false }),
-    [onClickEvent],
-  )
-
-  useEffect(() => {
-    window.addEventListener('click', throttledOnClickEvent)
-    //If validateSession call indicates an invalid MSCA session, redirect to logout
-    if (response?.status === 401) {
-      router.push(`/${props.locale}/auth/logout`)
-    }
-    //Remove event on unmount to prevent a memory leak with the cleanup
-    return () => {
-      window.removeEventListener('click', throttledOnClickEvent)
-    }
-  }, [throttledOnClickEvent, response, router, props.locale])
 
   const errorCode =
     props.content?.err ||
@@ -112,9 +91,38 @@ export default function Profile(props) {
 
 export async function getServerSideProps({ req, res, locale }) {
   const session = await getServerSession(req, res, authOptions)
+  const token = await getToken({ req })
 
   if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
+
+  //If Next-Auth session is valid, check to see if ECAS session is valid and clear cookies and redirect to login if not
+  if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
+    const sessionValid = await ValidateSession(
+      process.env.CLIENT_ID,
+      token?.sub,
+    )
+    if (!sessionValid) {
+      // Clear all session cookies
+      const isSecure = req.headers['x-forwarded-proto'] === 'https'
+      const cookiePrefix = `${isSecure ? '__Secure-' : ''}next-auth.session-token`
+      const cookies = []
+      for (const cookie of Object.keys(req.cookies)) {
+        if (cookie.startsWith(cookiePrefix)) {
+          cookies.push(
+            `${cookie}=deleted; Max-Age=0; path=/ ${isSecure ? '; Secure ' : ''}`,
+          )
+        }
+      }
+      res.setHeader('Set-Cookie', cookies)
+      return {
+        redirect: {
+          destination: `/${locale}/auth/login`,
+          permanent: false,
+        },
+      }
+    }
+  }
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('profile')

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -9,41 +9,20 @@ import { getBetaPopupExitContent } from '../graphql/mappers/beta-popup-exit'
 import { getBetaPopupNotAvailableContent } from '../graphql/mappers/beta-popup-page-not-available'
 import { getAuthModalsContent } from '../graphql/mappers/auth-modals'
 import { getLogger } from '../logging/log-util'
-import { AuthIsDisabled, AuthIsValid, Redirect } from '../lib/auth'
+import {
+  AuthIsDisabled,
+  AuthIsValid,
+  Redirect,
+  ValidateSession,
+} from '../lib/auth'
 import { authOptions } from '../pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
-import { useEffect, useCallback, useMemo, useState } from 'react'
-import throttle from 'lodash.throttle'
 import ErrorPage from '../components/ErrorPage'
-import { useRouter } from 'next/router'
 import Button from '../components/Button'
+import { getToken } from 'next-auth/jwt'
 
 export default function SecuritySettings(props) {
   const t = props.locale === 'en' ? en : fr
-  const [response, setResponse] = useState()
-  const router = useRouter()
-
-  //Event listener for click events that revalidates MSCA session, throttled using lodash to only trigger every 1 minute
-  const onClickEvent = useCallback(
-    async () => setResponse(await fetch('/api/refresh-msca')),
-    [],
-  )
-  const throttledOnClickEvent = useMemo(
-    () => throttle(onClickEvent, 60000, { trailing: false }),
-    [onClickEvent],
-  )
-
-  useEffect(() => {
-    window.addEventListener('click', throttledOnClickEvent)
-    //If validateSession call indicates an invalid MSCA session, redirect to logout
-    if (response?.status === 401) {
-      router.push(`/${props.locale}/auth/logout`)
-    }
-    //Remove event on unmount to prevent a memory leak with the cleanup
-    return () => {
-      window.removeEventListener('click', throttledOnClickEvent)
-    }
-  }, [throttledOnClickEvent, response, router, props.locale])
 
   const errorCode =
     props.content?.err ||
@@ -108,9 +87,38 @@ export default function SecuritySettings(props) {
 
 export async function getServerSideProps({ req, res, locale }) {
   const session = await getServerSession(req, res, authOptions)
+  const token = await getToken({ req })
 
   if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
+
+  //If Next-Auth session is valid, check to see if ECAS session is valid and clear cookies and redirect to login if not
+  if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
+    const sessionValid = await ValidateSession(
+      process.env.CLIENT_ID,
+      token?.sub,
+    )
+    if (!sessionValid) {
+      // Clear all session cookies
+      const isSecure = req.headers['x-forwarded-proto'] === 'https'
+      const cookiePrefix = `${isSecure ? '__Secure-' : ''}next-auth.session-token`
+      const cookies = []
+      for (const cookie of Object.keys(req.cookies)) {
+        if (cookie.startsWith(cookiePrefix)) {
+          cookies.push(
+            `${cookie}=deleted; Max-Age=0; path=/ ${isSecure ? '; Secure ' : ''}`,
+          )
+        }
+      }
+      res.setHeader('Set-Cookie', cookies)
+      return {
+        redirect: {
+          destination: `/${locale}/auth/login`,
+          permanent: false,
+        },
+      }
+    }
+  }
 
   //The below sets the minimum logging level to error and surpresses everything below that
   const logger = getLogger('security-settings')


### PR DESCRIPTION
## [ADO-202004](https://dev.azure.com/VP-BD/DECD/_workitems/edit/202004)

Fixed [AB#202004](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/202004)

### Changelog
fix:update validation logic to end next-auth session and redirect to login to re-auth

### Description of proposed changes:
The current validation logic on prod is lacking so this PR brings the changes that were made on dev while also addressing the RAOIDC bug by changing where the user is redirected to. Given the next-auth `signOut` event cannot be called from the server side, I instead clear the session cookie and then redirect to the login page to re-establish the RAOIDC session. This effectively does the same thing as the `signOut` event though this method may be vulnerable to next-auth changing their session cookie name prefix so that will be something to take into account when updating next-auth.

### What to test for/How to test
1. Pull in branch
2. Ensure auth is enabled and type `npm run dev`
3. Login to SYS2 Stream 3. Once logged in you will redirect to staging, manually navigate back to local
4. Once on the dashboard, manually navigate to CDCP (card isn't on main but you can find the link on dev, DM me if you have any issues finding it)
5. Manually navigate back to the dashboard, you should be redirected to `/auth/login` and redirected to the dashboard again after re-authing.
