### PR TITLE
Update next-auth config to use userinfo endpoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Debug MSCA-D frontend",
+      "command": "npm run dev",
+      "request": "launch",
+      "type": "node-terminal",
+      "cwd": "${workspaceFolder}"
+    },
+    {
       "type": "pwa-chrome",
       "request": "launch",
       "name": "Launch Chrome against localhost",

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,6 +1,7 @@
 import { getToken } from 'next-auth/jwt'
 import axios from 'axios'
 import { getLogger } from '../logging/log-util'
+import * as jose from 'jose'
 
 const logger = getLogger('auth-helpers')
 
@@ -17,6 +18,16 @@ export async function AuthIsValid(req, session) {
     return true
   }
   return false
+}
+
+//This function grabs the idToken from the getToken function and decodes it
+export async function getIdToken(req) {
+  const token = await getToken({ req })
+  if (token) {
+    const idToken = jose.decodeJwt(token.id_token)
+    return idToken
+  }
+  return token
 }
 
 export async function ValidateSession(clientId, sharedSessionId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "babel-plugin-macros": "^3.1.0",
         "cachified": "^3.5.4",
         "cross-env": "^7.0.3",
+        "jose": "^5.2.4",
         "lodash.throttle": "^4.1.1",
         "lru-cache": "^10.2.0",
         "markdown-to-jsx": "^7.4.5",
@@ -11635,9 +11636,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.4.tgz",
+      "integrity": "sha512-6ScbIk2WWCeXkmzF6bRPmEuaqy1m8SbsRFMa/FLrSCkGIhj8OLVG/IH+XHVmNMx/KUo8cVWEE6oKR4dJ+S0Rkg==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -13658,6 +13659,14 @@
         }
       }
     },
+    "node_modules/next-auth/node_modules/jose": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
+      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/next-i18next": {
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/next-i18next/-/next-i18next-13.3.0.tgz",
@@ -14157,6 +14166,14 @@
         "object-hash": "^2.2.0",
         "oidc-token-hash": "^5.0.3"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/jose": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
+      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-plugin-macros": "^3.1.0",
     "cachified": "^3.5.4",
     "cross-env": "^7.0.3",
+    "jose": "^5.2.4",
     "lodash.throttle": "^4.1.1",
     "lru-cache": "^10.2.0",
     "markdown-to-jsx": "^7.4.5",

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -104,7 +104,6 @@ export const authOptions: NextAuthOptions = {
     maxAge: 5 * 10 * 24, //20 minutes
   },
   callbacks: {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async jwt({ token, user, account }) {
       return { ...token, ...user, ...account }
     },

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -67,17 +67,17 @@ export const authOptions: NextAuthOptions = {
             })
             .then((response) => response)
             .catch((error) => logger.error(error))
-          const result = decryptJwe(
-            res?.data.userinfo_token,
-            process.env.AUTH_PRIVATE,
-          )
-          console.log(result)
           return res?.data
         },
       },
       idToken: true,
       checks: ['state', 'nonce'],
       profile: (profile) => {
+        const result = decryptJwe(
+          profile.userinfo_token as string,
+          process.env.AUTH_PRIVATE as string,
+        )
+        console.log(result)
         console.log('\n\n\nStart profile:\n')
         console.log(profile)
         console.log('\nEnd profile\n\n\n')
@@ -97,11 +97,8 @@ export const authOptions: NextAuthOptions = {
   },
   callbacks: {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async jwt({ token, account, user, profile }) {
-      if (profile) {
-        token.user = profile
-      }
-      return token
+    async jwt({ token, account, user }) {
+      return { ...token, ...account, ...user }
     },
     async redirect({ url, baseUrl }) {
       // Allows relative callback URLs

--- a/pages/api/refresh-msca.js
+++ b/pages/api/refresh-msca.js
@@ -3,11 +3,15 @@
  *
  */
 
-import { AuthIsDisabled, AuthIsValid, ValidateSession } from '../../lib/auth'
+import {
+  AuthIsDisabled,
+  AuthIsValid,
+  ValidateSession,
+  getIdToken,
+} from '../../lib/auth'
 import { getLogger } from '../../logging/log-util'
 import { authOptions } from '../../pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
-import { getToken } from 'next-auth/jwt'
 
 // Including crypto module
 const crypto = require('crypto')
@@ -18,7 +22,7 @@ logger.level = 'error'
 
 export default async function handler(req, res) {
   const session = await getServerSession(req, res, authOptions)
-  const token = await getToken({ req })
+  const token = await getIdToken(req)
   //Generate a random id for each request to ensure unique responses/no caching
   const id = crypto.randomBytes(20).toString('hex')
 
@@ -31,7 +35,7 @@ export default async function handler(req, res) {
       //If auth session is valid, make GET request to validateSession endpoint
       const sessionValid = await ValidateSession(
         process.env.CLIENT_ID,
-        token.sub
+        token.sid,
       )
       if (sessionValid) {
         res.status(200).json({ success: sessionValid, id: id })
@@ -46,7 +50,7 @@ export default async function handler(req, res) {
     //return unimplemented
     res.status(501).json({ success: false })
     logger.error(
-      'Something went wrong when trying reach the MSCA refresh endpoint'
+      'Something went wrong when trying reach the MSCA refresh endpoint',
     )
   }
 }

--- a/pages/auth/login.js
+++ b/pages/auth/login.js
@@ -5,8 +5,12 @@ import LoadingSpinner from '../../components/LoadingSpinner'
 import MetaData from '../../components/MetaData'
 import { authOptions } from '../../pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
-import { getToken } from 'next-auth/jwt'
-import { AuthIsDisabled, AuthIsValid, ValidateSession } from '../../lib/auth'
+import {
+  AuthIsDisabled,
+  AuthIsValid,
+  ValidateSession,
+  getIdToken,
+} from '../../lib/auth'
 
 export default function Login(props) {
   const router = useRouter()
@@ -57,13 +61,13 @@ export async function getServerSideProps({ req, res, locale }) {
   const authDisabled = AuthIsDisabled() ? true : false
 
   const session = await getServerSession(req, res, authOptions)
-  const token = await getToken({ req })
+  const token = await getIdToken(req)
 
   //If Next-Auth session is valid, check to see if ECAS session is and then redirect to dashboard instead of reinitiating auth
   if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
     const sessionValid = await ValidateSession(
       process.env.CLIENT_ID,
-      token?.sub,
+      token?.sid,
     )
     if (sessionValid) {
       return {

--- a/pages/contact-us/[id].tsx
+++ b/pages/contact-us/[id].tsx
@@ -14,11 +14,11 @@ import {
   AuthIsValid,
   ValidateSession,
   Redirect,
+  getIdToken,
 } from '../../lib/auth'
 import { authOptions } from '../api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
 import { GetServerSideProps } from 'next'
-import { getToken } from 'next-auth/jwt'
 
 interface Data {
   title: string
@@ -89,16 +89,17 @@ const ContactUsPage = (props: ContactUsPageProps) => {
 
 export const getServerSideProps = (async ({ req, res, locale, params }) => {
   const session = await getServerSession(req, res, authOptions)
-  const token = await getToken({ req })
 
   if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
+
+  const token = await getIdToken(req)
 
   //If Next-Auth session is valid, check to see if ECAS session is and redirect to logout if not
   if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
     const sessionValid = await ValidateSession(
       process.env.CLIENT_ID,
-      token?.sub,
+      token?.sid,
     )
     if (!sessionValid) {
       return {

--- a/pages/contact-us/index.tsx
+++ b/pages/contact-us/index.tsx
@@ -10,6 +10,7 @@ import {
   AuthIsValid,
   ValidateSession,
   Redirect,
+  getIdToken,
 } from '../../lib/auth'
 import { authOptions } from '../api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
@@ -17,7 +18,6 @@ import { GetServerSideProps } from 'next'
 import { BreadcrumbItem } from '../../components/Breadcrumb'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { icon } from '../../lib/loadIcons'
-import { getToken } from 'next-auth/jwt'
 
 interface Data {
   title: string
@@ -111,16 +111,17 @@ const ContactLanding = (props: ContactLandingProps) => {
 }
 export const getServerSideProps = (async ({ req, res, locale }) => {
   const session = await getServerSession(req, res, authOptions)
-  const token = await getToken({ req })
 
   if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
+
+  const token = await getIdToken(req)
 
   //If Next-Auth session is valid, check to see if ECAS session is and redirect to logout if not
   if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
     const sessionValid = await ValidateSession(
       process.env.CLIENT_ID,
-      token?.sub,
+      token?.sid,
     )
     if (!sessionValid) {
       return {

--- a/pages/decision-reviews.js
+++ b/pages/decision-reviews.js
@@ -9,6 +9,7 @@ import {
   AuthIsValid,
   ValidateSession,
   Redirect,
+  getIdToken,
 } from '../lib/auth'
 import { authOptions } from '../pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
@@ -16,7 +17,6 @@ import { getAuthModalsContent } from '../graphql/mappers/auth-modals'
 import Markdown from 'markdown-to-jsx'
 import ErrorPage from '../components/ErrorPage'
 import Button from '../components/Button'
-import { getToken } from 'next-auth/jwt'
 
 export default function DecisionReviews(props) {
   const t = props.locale === 'en' ? en : fr
@@ -116,14 +116,18 @@ export default function DecisionReviews(props) {
 
 export async function getServerSideProps({ req, res, locale }) {
   const session = await getServerSession(req, res, authOptions)
-  const token = await getToken({ req })
 
   if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
 
+  const token = await getIdToken(req)
+
   //If Next-Auth session is valid, check to see if ECAS session is and redirect to logout if not
   if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
-    const sessionValid = await ValidateSession(process.env.CLIENT_ID, token.sub)
+    const sessionValid = await ValidateSession(
+      process.env.CLIENT_ID,
+      token?.sid,
+    )
     if (!sessionValid) {
       return {
         redirect: {

--- a/pages/my-dashboard.js
+++ b/pages/my-dashboard.js
@@ -13,6 +13,7 @@ import {
   AuthIsValid,
   ValidateSession,
   Redirect,
+  getIdToken,
 } from '../lib/auth'
 import { authOptions } from '../pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
@@ -20,7 +21,6 @@ import BenefitTasks from './../components/BenefitTasks'
 import MostReqTasks from './../components/MostReqTasks'
 import { acronym } from '../lib/acronym'
 import ErrorPage from '../components/ErrorPage'
-import { getToken } from 'next-auth/jwt'
 
 export default function MyDashboard(props) {
   /* istanbul ignore next */
@@ -187,16 +187,17 @@ export default function MyDashboard(props) {
 
 export async function getServerSideProps({ req, res, locale }) {
   const session = await getServerSession(req, res, authOptions)
-  const token = await getToken({ req })
 
   if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
+
+  const token = await getIdToken(req)
 
   //If Next-Auth session is valid, check to see if ECAS session is and redirect to logout if not
   if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
     const sessionValid = await ValidateSession(
       process.env.CLIENT_ID,
-      token?.sub,
+      token?.sid,
     )
     if (!sessionValid) {
       return {

--- a/pages/privacy-notice-terms-conditions.js
+++ b/pages/privacy-notice-terms-conditions.js
@@ -12,6 +12,7 @@ import {
   AuthIsValid,
   ValidateSession,
   Redirect,
+  getIdToken,
 } from '../lib/auth'
 import { authOptions } from '../pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
@@ -20,7 +21,6 @@ import Markdown from 'markdown-to-jsx'
 import { getAuthModalsContent } from '../graphql/mappers/auth-modals'
 import React from 'react'
 import ErrorPage from '../components/ErrorPage'
-import { getToken } from 'next-auth/jwt'
 
 export default function PrivacyCondition(props) {
   const t = props.locale === 'en' ? en : fr
@@ -184,14 +184,18 @@ export default function PrivacyCondition(props) {
 
 export async function getServerSideProps({ req, res, locale }) {
   const session = await getServerSession(req, res, authOptions)
-  const token = await getToken({ req })
 
   if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
 
+  const token = await getIdToken(req)
+
   //If Next-Auth session is valid, check to see if ECAS session is and redirect to logout if not
   if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
-    const sessionValid = await ValidateSession(process.env.CLIENT_ID, token.sub)
+    const sessionValid = await ValidateSession(
+      process.env.CLIENT_ID,
+      token?.sid,
+    )
     if (!sessionValid) {
       return {
         redirect: {

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -11,6 +11,7 @@ import {
   AuthIsValid,
   ValidateSession,
   Redirect,
+  getIdToken,
 } from '../lib/auth'
 import { authOptions } from '../pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
@@ -18,7 +19,6 @@ import ProfileTasks from './../components/ProfileTasks'
 import React from 'react'
 import { acronym } from '../lib/acronym'
 import ErrorPage from '../components/ErrorPage'
-import { getToken } from 'next-auth/jwt'
 
 export default function Profile(props) {
   /* istanbul ignore next */
@@ -88,14 +88,18 @@ export default function Profile(props) {
 
 export async function getServerSideProps({ req, res, locale }) {
   const session = await getServerSession(req, res, authOptions)
-  const token = await getToken({ req })
 
   if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
 
+  const token = await getIdToken(req)
+
   //If Next-Auth session is valid, check to see if ECAS session is and redirect to logout if not
   if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
-    const sessionValid = await ValidateSession(process.env.CLIENT_ID, token.sub)
+    const sessionValid = await ValidateSession(
+      process.env.CLIENT_ID,
+      token?.sid,
+    )
     if (!sessionValid) {
       return {
         redirect: {

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -11,12 +11,12 @@ import {
   AuthIsValid,
   ValidateSession,
   Redirect,
+  getIdToken,
 } from '../lib/auth'
 import { authOptions } from '../pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth/next'
 import ErrorPage from '../components/ErrorPage'
 import Button from '../components/Button'
-import { getToken } from 'next-auth/jwt'
 
 export default function SecuritySettings(props) {
   const t = props.locale === 'en' ? en : fr
@@ -84,14 +84,18 @@ export default function SecuritySettings(props) {
 
 export async function getServerSideProps({ req, res, locale }) {
   const session = await getServerSession(req, res, authOptions)
-  const token = await getToken({ req })
 
   if (!AuthIsDisabled() && !(await AuthIsValid(req, session)))
     return Redirect(locale)
 
+  const token = await getIdToken(req)
+
   //If Next-Auth session is valid, check to see if ECAS session is and redirect to logout if not
   if (!AuthIsDisabled() && (await AuthIsValid(req, session))) {
-    const sessionValid = await ValidateSession(process.env.CLIENT_ID, token.sub)
+    const sessionValid = await ValidateSession(
+      process.env.CLIENT_ID,
+      token?.sid,
+    )
     if (!sessionValid) {
       return {
         redirect: {


### PR DESCRIPTION
## [ADO-204138](https://dev.azure.com/VP-BD/DECD/_workitems/edit/204138)

Fixed [AB#204138](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/204138)

### Changelog 
feat: update next-auth configuration to explicitly use the userinfo endpoint to obtain SIN
feat: added helper function to decode idToken so validation continues to work

### Description of proposed changes:
This PR updates our next-auth config to explicitly use the `userinfo` endpoint. This is necessary because when using the `well-known` endpoint for discovery, next-auth by default will decode and obtain information from the id_token instead of make a request to the `userinfo` endpoint, where the SIN and UID live. In this PR, a function to decrypt the `userinfo_token` returned from the `userinfo` endpoint is introduced which takes in the token and decrypts it using our private key. The only caveat is that jose (the library used to decrypt and decode the token) expects/supports a certain signing algorithm which our private key does not explicitly declare. Simply adding `RS256` to the end of the environment variable will make the decryption of the `userinfo_token` work, but for some reason breaks the decryption of the id_token, which next-auth handles behind the scenes. This might require a regeneration of our keyset, but for now I've declared a new variable which I parse and add the `alg` field to in order to use with the `userinfo_token` decryption. This PR also includes configuration to debug the application, since that wasn't present before.

### What to test for/How to test
1. Pull in branch
2. Ensure auth is enabled
3. Type `npm run dev`
4. Login and ensure the application runs as expected.
