### PR TITLE
Explicitly add https to BRZ API call

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -91,7 +91,7 @@ export const authOptions: NextAuthOptions = {
         //Make call to msca-ng API to update last login date
         const response = await axios
           .post(
-            `${process.env.HOSTALIAS_HOSTNAME}${process.env.MSCA_NG_USER_ENDPOINT}`,
+            `https://${process.env.HOSTALIAS_HOSTNAME}${process.env.MSCA_NG_USER_ENDPOINT}`,
             {
               pid: profile.sin,
               spid: profile.uid,


### PR DESCRIPTION
### Changelog
fix:update url for BRZ API call to explicitly have https

### Description of proposed changes:
This PR adds https to the beginning of the link for the BRZ API call because it is not specified in our environment variable and axios seems to expect it

### What to test for/How to test
1. Cannot test until merged to staging
