### PR TITLE
Local Settings for Cert Setup for Review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ AUTH_ECAS_USERINFO="ECAS userinfo endpoint"
 AUTH_PRIVATE={  "kty": "RSA",  "n": "example private key" }
 AUTH_DISABLED="set to 'true' to disable authentiation"
 SWAP_USER_TESTING_LINKS = "Set true to use UT links"
+MSCA_NG_CERT_LOCATION="./env.crt"
 
 # OpenTelemetry/Dynatrace settings
 # Note: to disable metrics and/or tracing exporting, leave the respective endpoint undefined

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ yarn-error.log*
 .env
 .env.local
 
+#cert
+env.crt
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ ARG user=nodeuser
 ARG group=nodegroup
 ARG home=/srv/app
 
+ARG MSCA_NG_CERT_LOCATION=/usr/local/share/ca-certificates/env.crt
+ENV MSCA_NG_CERT_LOCATION=$MSCA_NG_CERT_LOCATION
+
 RUN addgroup \
     -S ${group} \
     --gid 1001 && \
@@ -48,7 +51,7 @@ RUN addgroup \
 
 WORKDIR ${home}
 
-COPY --from=build --chown=${user}:${group} /usr/local/share/ca-certificates/env.crt /usr/local/share/ca-certificates/env.crt
+COPY --from=build --chown=${user}:${group} /usr/local/share/ca-certificates/env.crt ${MSCA_NG_CERT_LOCATION}
 
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/* && update-ca-certificates
 

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -25,6 +25,16 @@ async function decryptJwe(jwe: string, jwk: any) {
   return jose.decodeJwt(decryptResult.plaintext.toString())
 }
 
+//Create httpsAgent to read in cert to make BRZ call
+const httpsAgent =
+  process.env.AUTH_DISABLED === 'true'
+    ? new https.Agent()
+    : new https.Agent({
+        ca: fs.readFileSync(
+          process.env.MSCA_NG_CERT_LOCATION as fs.PathOrFileDescriptor,
+        ),
+      })
+
 export const authOptions: NextAuthOptions = {
   providers: [
     {
@@ -103,9 +113,7 @@ export const authOptions: NextAuthOptions = {
                 'authorization': `Basic ${process.env.MSCA_NG_CREDS}`,
                 'Content-Type': 'application/json',
               },
-              httpsAgent: new https.Agent({
-                ca: fs.readFileSync('/usr/local/share/ca-certificates/env.crt'),
-              }),
+              httpsAgent: httpsAgent,
             },
           )
           .then((response) => response)


### PR DESCRIPTION
### Description of proposed changes:
- Removes the hardcoded path from the MSCA NG API cert
- Adds in the option to disable cert loading for auth disable environments

### What to test for/How to test
This shouldn't actually disrupt anything other than on local you can now load a cert from another location (say, locally from ./env.crt)

### Additional Notes
