### PR TITLE
Add separate axios call to update user login date

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -100,8 +100,8 @@ export const authOptions: NextAuthOptions = {
       checks: ['state', 'nonce'],
       profile: async (profile) => {
         profile = await decryptJwe(profile.userinfo_token, jwk)
-        //Make call to msca-ng API to update last login date
-        const response = await axios
+        //Make call to msca-ng API to create user if it doesn't exist
+        axios
           .post(
             `https://${process.env.HOSTALIAS_HOSTNAME}${process.env.MSCA_NG_USER_ENDPOINT}`,
             {
@@ -116,9 +116,21 @@ export const authOptions: NextAuthOptions = {
               httpsAgent: httpsAgent,
             },
           )
-          .then((response) => response)
+          .then((response) => logger.debug(response))
           .catch((error) => logger.error(error))
-        logger.debug(response)
+
+        //Make call to msca-ng API to update last login date of user
+        axios({
+          method: 'post',
+          url: `https://${process.env.HOSTALIAS_HOSTNAME}${process.env.MSCA_NG_USER_ENDPOINT}/${profile.uid}/logins`,
+          headers: {
+            'Authorization': `Basic ${process.env.MSCA_NG_CREDS}`,
+            'Content-Type': 'application/json',
+          },
+          httpsAgent: httpsAgent,
+        })
+          .then((response) => logger.debug(response))
+          .catch((error) => logger.error(error))
         return {
           id: profile.sub,
           ...profile,


### PR DESCRIPTION
### Changelog
feat:add separate axios call to update user's last login date

### Description of proposed changes:
I was previously unaware that we were required to make an API call to another endpoint in order to update the user's login date. This PR adds that as a separate POST request.

### What to test for/How to test
1. Can't really test unless on staging. If you wish to test locally, send me a message to get set up with a mock Prism server.
