### PR TITLE
Update contact us page to display SIN link

### DIFF
--- a/cypress/e2e/ContactUs.cy.js
+++ b/cypress/e2e/ContactUs.cy.js
@@ -22,7 +22,7 @@ describe('Validate Contact Us Landing page', () => {
     cy.get('[data-cy = "contact-task-list"]')
     .find('a')
     .should('be.visible')
-    .and('have.length', '3')
+    .and('have.length', '4')
     .and('not.have.length', 0)
     .and('not.have.attr', 'href', '#undefined')
   })

--- a/graphql/mappers/contact-us.ts
+++ b/graphql/mappers/contact-us.ts
@@ -74,7 +74,7 @@ const getCachedContent = () => {
     cache,
     getFreshValue: async () => {
       const response = await fetch(
-        `${process.env.AEM_GRAPHQL_ENDPOINT}getSchContactUsV1`
+        `${process.env.AEM_GRAPHQL_ENDPOINT}getSchContactUsV1`,
       )
       if (!response.ok) return null
       return (await response.json()) as GetSchContactUsV1
@@ -82,7 +82,7 @@ const getCachedContent = () => {
     ttl,
   })
 }
- 
+
 /**
  * Awaited: Recursively unwraps the "awaited type" of a type.
  * ReturnType: Obtain the return type of a function type
@@ -98,6 +98,7 @@ export async function getContactUsContent() {
   const eiContactFragment = findFragmentByScId(response, 'ei-contact-us')
   const oasContactFragment = findFragmentByScId(response, 'oas-contact-us')
   const cppContactFragment = findFragmentByScId(response, 'cpp-contact-us')
+  const sinContactFragment = findFragmentByScId(response, 'sin-contact-us')
 
   const mappedSecurity = {
     en: {
@@ -108,7 +109,7 @@ export async function getContactUsContent() {
               link: level.scPageNameEn,
               text: level.scTitleEn,
             }
-          }
+          },
         ),
       pageName: response?.data.schPageV1ByPath.item.scPageNameEn,
       heading: response?.data.schPageV1ByPath.item.scTitleEn,
@@ -144,6 +145,16 @@ export async function getContactUsContent() {
             : '',
           schBetaPopup: oasContactFragment?.schBetaPopUp,
         },
+        {
+          linkId: sinContactFragment?.scId,
+          linkTitle: sinContactFragment?.scLinkTextEn,
+          linkAssistiveTitle: sinContactFragment?.scLinkTextAssistiveEn,
+          linkDestination: sinContactFragment?.scDestinationURLEn,
+          linkDescription: sinContactFragment?.scDescriptionEn?.json
+            ? sinContactFragment.scDescriptionEn.json[0].content[0].value
+            : '',
+          schBetaPopup: sinContactFragment?.schBetaPopUp,
+        },
       ],
     },
     fr: {
@@ -154,7 +165,7 @@ export async function getContactUsContent() {
               link: level.scPageNameFr,
               text: level.scTitleFr,
             }
-          }
+          },
         ),
       pageName: response?.data.schPageV1ByPath.item.scPageNameFr,
       heading: response?.data.schPageV1ByPath.item.scTitleFr,
@@ -190,6 +201,16 @@ export async function getContactUsContent() {
             : '',
           schBetaPopup: oasContactFragment?.schBetaPopUp,
         },
+        {
+          linkId: sinContactFragment?.scId,
+          linkTitle: sinContactFragment?.scLinkTextFr,
+          linkAssistiveTitle: sinContactFragment?.scLinkTextAssistiveFr,
+          linkDestination: sinContactFragment?.scDestinationURLFr,
+          linkDescription: sinContactFragment?.scDescriptionFr?.json
+            ? sinContactFragment.scDescriptionFr.json[0].content[0].value
+            : '',
+          schBetaPopup: sinContactFragment?.schBetaPopUp,
+        },
       ],
     },
   }
@@ -199,7 +220,7 @@ export async function getContactUsContent() {
 const findFragmentByScId = (res: GetSchContactUsV1 | null, id: string) => {
   return (
     res?.data.schPageV1ByPath.item.scFragments.find(
-      ({ scId }) => scId === id
+      ({ scId }) => scId === id,
     ) ?? null
   )
 }

--- a/pages/contact-us/index.tsx
+++ b/pages/contact-us/index.tsx
@@ -64,11 +64,15 @@ const ContactLanding = (props: ContactLandingProps) => {
                 id={link.linkId}
                 data-testid={link.linkId}
                 aria-label={link.linkTitle}
-                href={`/${props.locale}/${props.content.pageName}/${(
-                  link.linkDestination ?? ''
-                )
-                  .split('/')
-                  .pop()}`}
+                href={
+                  link.linkDestination?.includes('http')
+                    ? link.linkDestination
+                    : `/${props.locale}/${props.content.pageName}/${(
+                        link.linkDestination ?? ''
+                      )
+                        .split('/')
+                        .pop()}`
+                }
                 data-gc-analytics-customclick={`ESDC-EDSC_MSCA-MSDC-SCH:Contact Us:${link.linkTitle}`}
                 target={
                   newTabExceptions.includes(link.linkDestination ?? '')


### PR DESCRIPTION
## [ADO-249297](https://dev.azure.com/VP-BD/DECD/_workitems/edit/249297)

Fixed [AB#249297](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/249297)

### Changelog
feat:Updated contact us mapper and contact us page to display SIN

### Description of proposed changes:
This PR updates our contact-us mapper with the SIN links and the contact-us index page to accommodate external links.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to the contact us page and ensure that the SIN link is there and clicking it opens the canada.ca link in a new tab

### Additional Notes
I feel like the contact-us mapper could potentially be made dynamic so we don't have to manually make these changes in the future. So something to look into.