### PR TITLE
Update next-auth config to validate SIN and UID

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -100,6 +100,15 @@ export const authOptions: NextAuthOptions = {
       checks: ['state', 'nonce'],
       profile: async (profile) => {
         profile = await decryptJwe(profile.userinfo_token, jwk)
+
+        //Validate SIN and UID to ensure they are not null and are alphanumeric
+        const sinRegex = /^[a-zA-Z0-9]+$/
+        if (profile.sin === null || !sinRegex.test(profile.sin)) {
+          logger.error('SIN is not valid')
+        } else if (profile.uid === null || !sinRegex.test(profile.uid)) {
+          logger.error('UID is not valid')
+        }
+
         //Make call to msca-ng API to create user if it doesn't exist
         axios
           .post(


### PR DESCRIPTION
## [ADO-266898](https://dev.azure.com/VP-BD/DECD/_workitems/edit/266898)

Fixed [AB#266898](https://dev.azure.com/VP-BD/d5ca3cd4-19cb-4c8c-b3e6-a7068f4677e4/_workitems/edit/266898)

### Changelog
feat:add logging for SIN and UID validation

### Description of proposed changes:
This PR adds validation that checks the SIN and UID returned from the userinfo endpoint to see if they are null or not alphanumeric and logs an error if either condition isn't met.

### What to test for/How to test
1. Pull in branch
2. Ensure cert path in Next-Auth config is changed to your local cert path (if you aren't running in Docker)
3. Type `npm run dev`
4. Login and navigate back to MSCA-D
5. Confirm there aren't any error logs saying the values aren't valid (you can also change the condition to look for true to force the error)
