### PR TITLE
simplify handling for meiio stream3 links

### DIFF
--- a/graphql/mappers/my-dashboard.ts
+++ b/graphql/mappers/my-dashboard.ts
@@ -137,13 +137,7 @@ export async function getMyDashboardContent() {
                     id: item.scId,
                     title: item.scLinkTextEn,
                     areaLabel: item.scLinkTextAssistiveEn,
-                    link: buildLink(
-                      item.schURLType,
-                      process.env.ENVIRONMENT === 'development' &&
-                        item.scDestinationURL3En !== null
-                        ? item.scDestinationURL3En
-                        : item.scDestinationURLEn,
-                    ),
+                    link: buildLink(item.schURLType, item.scDestinationURLEn),
                     icon: item.scIconCSS,
                     betaPopUp: item.schBetaPopUp,
                   }
@@ -196,13 +190,7 @@ export async function getMyDashboardContent() {
                     id: item.scId,
                     title: item.scLinkTextFr,
                     areaLabel: item.scLinkTextAssistiveFr,
-                    link: buildLink(
-                      item.schURLType,
-                      process.env.ENVIRONMENT === 'development' &&
-                        item.scDestinationURL3Fr !== null
-                        ? item.scDestinationURL3Fr
-                        : item.scDestinationURLFr,
-                    ),
+                    link: buildLink(item.schURLType, item.scDestinationURLFr),
                     icon: item.scIconCSS,
                     betaPopUp: item.schBetaPopUp,
                   }

--- a/graphql/mappers/my-dashboard.ts
+++ b/graphql/mappers/my-dashboard.ts
@@ -70,8 +70,6 @@ interface GetSchMyDashboardV2 {
                 schURLType?: string
                 scDestinationURLEn: string
                 scDestinationURLFr: string
-                scDestinationURL3En?: string | null
-                scDestinationURL3Fr?: string | null
                 scIconCSS: string
                 schBetaPopUp: boolean
               }>


### PR DESCRIPTION
ARB rules will overcome the stream3 meiio path variant, instead of relying on AEM-sensitive logic.

### What to test for/How to test
meiio links will no longer have `_ii` in the path

### Additional Notes
An ARB reverse proxy rule for stream3 will be created to map `meiio-mraed` path to `meiio-mraed_II`