### PR TITLE
Use next/script and move AA script out of Head

### DIFF
--- a/components/MetaData.tsx
+++ b/components/MetaData.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head'
+import Script from 'next/script'
 
 interface Content {
   title: string
@@ -57,16 +58,19 @@ const MetaData = ({ language, data }: MetaDataProps) => {
         <meta name="dcterms.creator" content={d.creator} />
         <meta name="dcterms.accessRights" content={d.accessRights} />
         <meta name="dcterms.service" content={d.service} />
-        {/* eslint-disable */}
-
-        {process.env.ENVIRONMENT === 'production' ? (
-          <script src="//assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-59d77766b86a.min.js"></script>
-        ) : (
-          <script src="https://assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-cad75bf2f0d2-staging.min.js"></script>
-        )}
-
-        {/*eslint-enable */}
       </Head>
+
+      {process.env.ENVIRONMENT === 'production' ? (
+        <Script
+          strategy="afterInteractive"
+          src="//assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-59d77766b86a.min.js"
+        />
+      ) : (
+        <Script
+          strategy="afterInteractive"
+          src="https://assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-cad75bf2f0d2-staging.min.js"
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
## [ADO-280112](https://dev.azure.com/VP-BD/DECD/_workitems/edit/280112)

Work towards and potential fix for 280112

### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary

### Description of proposed changes:

Changed to not use `<script>` to import AA in Head since this isn't allowed (https://nextjs.org/docs/messages/no-script-tags-in-head-component) and moved it outside and used `next/script` instead.

### What to test for/How to test

AA script should appear in the body instead of the head. Also, on monitoring the network activity there should only be one download of the AA script instead of two.

### Additional Notes
