### PR TITLE
Reduce replicaCount and minReplicas to 1 for dev environments.

### DIFF
--- a/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
@@ -144,7 +144,7 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-replicaCount: 2
+replicaCount: 1
 resources:
   requests:
     cpu: 300m
@@ -194,7 +194,7 @@ secrets:
 autoscaling:
   enabled: true
   name: service-canada-client-hub
-  minReplicas: 2
+  minReplicas: 1
   maxReplicas: {{ env "HPA_MAX_REPLICAS" | default 40}}
   targetCPUUtilization: 85
   labels:


### PR DESCRIPTION
### Description of proposed changes:
Change `replicaCount` and `minReplica` settings in dev. When deployed, we should also change `HPA_MAX_REPLICAS` env var in teamcity to a suitable number.

This change will reduce costs for the dev environment. Given that we (will) have so many deployed instances of MSCA-D, and additional resources increase the cost of hosting, we should use as few replications are are necessary to support the type of testing therein. For Performance testing, we would need to ensure that the maximum number of replicas is high enough to support the expected load.
