### PR TITLE
Load AA script before interactive to see if there's a race condition

### DIFF
--- a/components/MetaData.tsx
+++ b/components/MetaData.tsx
@@ -62,12 +62,12 @@ const MetaData = ({ language, data }: MetaDataProps) => {
 
       {process.env.ENVIRONMENT === 'production' ? (
         <Script
-          strategy="afterInteractive"
+          strategy="beforeInteractive"
           src="//assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-59d77766b86a.min.js"
         />
       ) : (
         <Script
-          strategy="afterInteractive"
+          strategy="beforeInteractive"
           src="https://assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-cad75bf2f0d2-staging.min.js"
         />
       )}


### PR DESCRIPTION
## [ADO-280112](https://dev.azure.com/VP-BD/DECD/_workitems/edit/280112)

Additional work to attempt to fix double AA count.

### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary

### Description of proposed changes:
Change to load the AA script as soon as possible. Currently, the page waits until it is interactive.

### What to test for/How to test
No impact on page, but if it fixes the problem then AA should be able to see the initial page load.

### Additional Notes
Testing of previous version of code indicates that AA doesn't get the page load when logging in or refreshing, but does when navigating from page to page. Given that seemingly everything else works fine and local testing shows no problems, this suggests some sort of race condition when first loading the page.