### PR TITLE
Add analytics tags for error pages and don't fire the pageLoad beacon

### DIFF
--- a/__tests__/components/Layout.test.js
+++ b/__tests__/components/Layout.test.js
@@ -73,6 +73,10 @@ describe('Layout with default text', () => {
   useRouter.mockImplementation(() => ({
     pathname: '/',
     asPath: '/',
+    events: {
+      on: jest.fn(),
+      off: jest.fn(),
+    },
   }))
 
   it.skip('Layout contains Symbol of GoC', () => {

--- a/__tests__/pages/contact-us-pages.test.js
+++ b/__tests__/pages/contact-us-pages.test.js
@@ -57,6 +57,10 @@ describe.skip('Dynamic Contact Us Page', () => {
     useRouter.mockImplementation(() => ({
       pathname: '/',
       asPath: '/',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
     }))
   })
 

--- a/__tests__/pages/decision-reviews.test.js
+++ b/__tests__/pages/decision-reviews.test.js
@@ -81,6 +81,10 @@ describe('Decision Reviews page', () => {
     useRouter.mockImplementation(() => ({
       pathname: '/',
       asPath: '/',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
     }))
   })
 
@@ -94,10 +98,10 @@ describe('Decision Reviews page', () => {
         meta={{}}
         breadCrumbItems={content.breadcrumb}
         langToggleLink={''}
-      />
+      />,
     )
     const DecisionReviewsDiv = screen.getByTestId(
-      'decision-reviewsContent-test'
+      'decision-reviewsContent-test',
     )
     expect(DecisionReviewsDiv).toBeInTheDocument()
   })
@@ -112,10 +116,10 @@ describe('Decision Reviews page', () => {
         meta={{}}
         breadCrumbItems={content.breadcrumb}
         langToggleLink={''}
-      />
+      />,
     )
     const DecisionReviewsDiv = screen.getByTestId(
-      'decision-reviewsContent-test'
+      'decision-reviewsContent-test',
     )
     expect(DecisionReviewsDiv).toBeInTheDocument()
   })

--- a/__tests__/pages/index.test.js
+++ b/__tests__/pages/index.test.js
@@ -33,6 +33,10 @@ describe('index page', () => {
     useRouter.mockImplementation(() => ({
       pathname: '/',
       asPath: '/',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
     }))
   })
 

--- a/__tests__/pages/login.test.js
+++ b/__tests__/pages/login.test.js
@@ -39,6 +39,10 @@ describe('login page', () => {
     useRouter.mockImplementation(() => ({
       pathname: '/auth/login',
       asPath: '/auth/login',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
     }))
   })
 

--- a/__tests__/pages/logout.test.js
+++ b/__tests__/pages/logout.test.js
@@ -43,6 +43,10 @@ describe('logout page', () => {
     useRouter.mockImplementation(() => ({
       pathname: '/auth/logout',
       asPath: '/auth/logout',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
     }))
   })
 

--- a/__tests__/pages/my-dashboard.test.js
+++ b/__tests__/pages/my-dashboard.test.js
@@ -65,6 +65,10 @@ describe('My Dashboard page', () => {
     useRouter.mockImplementation(() => ({
       pathname: '/',
       asPath: '/',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
     }))
   })
 

--- a/__tests__/pages/profile.test.js
+++ b/__tests__/pages/profile.test.js
@@ -69,6 +69,10 @@ describe('My Profile page', () => {
     useRouter.mockImplementation(() => ({
       pathname: '/',
       asPath: '/',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
     }))
   })
 
@@ -86,7 +90,7 @@ describe('My Profile page', () => {
         popupContentNA={popupContent}
         breadCrumbItems={[]}
         langToggleLink={''}
-      />
+      />,
     )
     const profileDiv = screen.getByTestId('profileContent-test')
     expect(profileDiv).toBeInTheDocument()
@@ -106,7 +110,7 @@ describe('My Profile page', () => {
         popupContentNA={popupContent}
         breadCrumbItems={[]}
         langToggleLink={''}
-      />
+      />,
     )
     const profileDiv = screen.getByTestId('profileContent-test')
     expect(profileDiv).toBeInTheDocument()

--- a/__tests__/pages/security-settings.test.js
+++ b/__tests__/pages/security-settings.test.js
@@ -50,6 +50,10 @@ describe('Security Settings page', () => {
     useRouter.mockImplementation(() => ({
       pathname: '/',
       asPath: '/',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
     }))
   })
 
@@ -63,7 +67,7 @@ describe('Security Settings page', () => {
         meta={{}}
         breadCrumbItems={content.breadcrumb}
         langToggleLink={''}
-      />
+      />,
     )
     const SecuritySettingsDiv = screen.getByTestId('securityContent-test')
     expect(SecuritySettingsDiv).toBeInTheDocument()
@@ -79,7 +83,7 @@ describe('Security Settings page', () => {
         meta={{}}
         breadCrumbItems={content.breadcrumb}
         langToggleLink={''}
-      />
+      />,
     )
     const SecuritySettingsDiv = screen.getByTestId('securityContent-test')
     expect(SecuritySettingsDiv).toBeInTheDocument()
@@ -95,7 +99,7 @@ describe('Security Settings page', () => {
         meta={{}}
         breadCrumbItems={content.breadcrumb}
         langToggleLink={''}
-      />
+      />,
     )
     const securityQuestionsLink = screen.getByTestId('securityQuestionsLink')
     expect(securityQuestionsLink).toBeInTheDocument()

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -6,6 +6,7 @@ import MetaData from './MetaData'
 import en from '../locales/en'
 import fr from '../locales/fr'
 import { lato, notoSans } from '../utils/fonts'
+import { useRouter } from 'next/router'
 import throttle from 'lodash.throttle'
 import IdleTimeout from './IdleTimeout'
 import { signOut } from 'next-auth/react'
@@ -14,6 +15,7 @@ import getConfig from 'next/config'
 export default function Layout(props) {
   const t = props.locale === 'en' ? en : fr
   const [response, setResponse] = useState()
+  const router = useRouter()
   const defaultBreadcrumbs = []
   const contactLink =
     props.locale === 'en' ? '/en/contact-us' : '/fr/contactez-nous'

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -6,7 +6,6 @@ import MetaData from './MetaData'
 import en from '../locales/en'
 import fr from '../locales/fr'
 import { lato, notoSans } from '../utils/fonts'
-import { useRouter } from 'next/router'
 import throttle from 'lodash.throttle'
 import IdleTimeout from './IdleTimeout'
 import { signOut } from 'next-auth/react'
@@ -15,7 +14,6 @@ import getConfig from 'next/config'
 export default function Layout(props) {
   const t = props.locale === 'en' ? en : fr
   const [response, setResponse] = useState()
-  const router = useRouter()
   const defaultBreadcrumbs = []
   const contactLink =
     props.locale === 'en' ? '/en/contact-us' : '/fr/contactez-nous'

--- a/components/MetaData.tsx
+++ b/components/MetaData.tsx
@@ -11,7 +11,7 @@ interface Content {
   creator: string
   accessRights: string
   service: string
-  statusCode: string
+  statusCode?: string
 }
 
 interface Data {

--- a/components/MetaData.tsx
+++ b/components/MetaData.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head'
-import router from 'next/router'
+import { useRouter } from 'next/router'
 import Script from 'next/script'
 import { useEffect } from 'react'
 
@@ -37,6 +37,7 @@ declare global {
 /* eslint-enable */
 
 const MetaData = ({ language, data }: MetaDataProps) => {
+  const router = useRouter()
   const d = language === 'en' ? data.data_en : data.data_fr
   const isErrorPage = typeof d.statusCode !== 'undefined'
   /** Web Analytics - taken from Google Analytics example

--- a/components/MetaData.tsx
+++ b/components/MetaData.tsx
@@ -1,5 +1,7 @@
 import Head from 'next/head'
+import router from 'next/router'
 import Script from 'next/script'
+import { useEffect } from 'react'
 
 interface Content {
   title: string
@@ -9,6 +11,7 @@ interface Content {
   creator: string
   accessRights: string
   service: string
+  statusCode: string
 }
 
 interface Data {
@@ -21,8 +24,45 @@ interface MetaDataProps {
   data: Data
 }
 
+// To help prevent double firing of adobe analytics pageLoad event
+let appPreviousLocationPathname = ''
+
+/* eslint-disable */
+// make typescript happy
+declare global {
+  interface Window {
+    adobeDataLayer: any
+  }
+}
+/* eslint-enable */
+
 const MetaData = ({ language, data }: MetaDataProps) => {
   const d = language === 'en' ? data.data_en : data.data_fr
+  const isErrorPage = typeof d.statusCode !== 'undefined'
+  /** Web Analytics - taken from Google Analytics example
+   *  @see https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics
+   * */
+  useEffect(() => {
+    const handleRouteChange = () => {
+      // only push event if pathname is different
+      if (window.location.pathname !== appPreviousLocationPathname) {
+        window.adobeDataLayer?.push?.({ event: 'pageLoad' })
+        appPreviousLocationPathname = window.location.pathname
+      }
+    }
+    if (isErrorPage) {
+      // Suppress the pageLoad entirely on error pages
+      return
+    }
+
+    handleRouteChange()
+    router.events.on('routeChangeComplete', handleRouteChange)
+    router.events.on('hashChangeComplete', handleRouteChange)
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+      router.events.off('hashChangeComplete', handleRouteChange)
+    }
+  }, [router.events])
 
   return (
     <>
@@ -42,8 +82,12 @@ const MetaData = ({ language, data }: MetaDataProps) => {
             }
           `}
         </style>
+        {isErrorPage ? (
+          <title data-gc-analytics-error={d.statusCode}>{d.title}</title>
+        ) : (
+          <title>{d.title}</title>
+        )}
 
-        <title>{d.title}</title>
         <meta charSet="utf-8" />
         <meta name="description" content={d.desc} />
         <meta name="author" content={d.author} />

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -60,6 +60,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       service: 'ESDC-EDSC_MSCA-MSDC-SCH',
       creator: 'Employment and Social Development Canada',
       accessRights: '1',
+      statusCode: '404',
     },
     data_fr: {
       title: `Nous ne pouvons trouver cette page Web - 404 - Mon dossier Service Canada`,
@@ -69,6 +70,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       service: 'ESDC-EDSC_MSCA-MSDC-SCH',
       creator: 'Emploi et Développement social Canada',
       accessRights: '1',
+      statusCode: '404',
     },
   }
   return {

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -60,6 +60,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       service: 'ESDC-EDSC_MSCA-MSDC-SCH',
       creator: 'Employment and Social Development Canada',
       accessRights: '1',
+      statusCode: '500',
     },
     data_fr: {
       title: `Nous ne pouvons trouver cette page Web - 500 - Mon dossier Service Canada`,
@@ -69,6 +70,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       service: 'ESDC-EDSC_MSCA-MSDC-SCH',
       creator: 'Emploi et Développement social Canada',
       accessRights: '1',
+      statusCode: '500',
     },
   }
   return {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,9 +8,6 @@ import ErrorBoundary from '../components/ErrorBoundary'
 import { useEffect } from 'react'
 config.autoAddCss = false
 
-// To help prevent double firing of adobe analytics pageLoad event
-let appPreviousLocationPathname = ''
-
 export default function MyApp({ Component, pageProps, router }) {
   /* istanbul ignore next */
   if (Component.getLayout) {
@@ -19,27 +16,6 @@ export default function MyApp({ Component, pageProps, router }) {
 
   Modal.setAppElement('#__next')
   const display = { hideBanner: pageProps.hideBanner }
-
-  /** Web Analytics - taken from Google Analytics example
-   *  @see https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics
-   * */
-  useEffect(() => {
-    const handleRouteChange = () => {
-      // only push event if pathname is different
-      if (window.location.pathname !== appPreviousLocationPathname) {
-        window.adobeDataLayer?.push?.({ event: 'pageLoad' })
-        appPreviousLocationPathname = window.location.pathname
-      }
-    }
-
-    handleRouteChange()
-    router.events.on('routeChangeComplete', handleRouteChange)
-    router.events.on('hashChangeComplete', handleRouteChange)
-    return () => {
-      router.events.off('routeChangeComplete', handleRouteChange)
-      router.events.off('hashChangeComplete', handleRouteChange)
-    }
-  }, [router.events])
 
   /* istanbul ignore next */
   return (


### PR DESCRIPTION
## [ADO-280112](https://dev.azure.com/VP-BD/DECD/_workitems/edit/280112)

### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary

### Description of proposed changes:

Add analytics tags for 404 and 500 pages.
Don't fire the pageLoad beacon on those pages.

### What to test for/How to test

See analytics fire on the 404/500 pages and the pageLoad doesn't.

### Additional Notes
