### PR TITLE
accomodate cert chain for raoidc sade environments on new 10 dot star…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ARG HOSTALIAS_CERT
 ENV HOSTALIAS_CERT=$HOSTALIAS_CERT
 ARG HOSTALIAS_ROOT_CERT
 ENV HOSTALIAS_ROOT_CERT=$HOSTALIAS_ROOT_CERT
+ARG AUTH_ECAS_CA
+ENV AUTH_ECAS_CA=$AUTH_ECAS_CA
 ARG LOGGING_LEVEL=info
 ENV LOGGING_LEVEL=$LOGGING_LEVEL
 ARG AEM_GRAPHQL_ENDPOINT=https://www.canada.ca/graphql/execute.json/decd-endc/
@@ -34,6 +36,11 @@ sed 's/\\n/\n/g' | \
 xargs > \
 /usr/local/share/ca-certificates/env.crt && \
 chmod 644 /usr/local/share/ca-certificates/env.crt && \
+echo ${AUTH_ECAS_CA} | \
+sed 's/\\n/\n/g' | \
+xargs > \
+/usr/local/share/ca-certificates/ecas_env.crt && \
+chmod 644 /usr/local/share/ca-certificates/ecas_env.crt && \
 mkdir -p  /etc/ssl/certs/ && \
 echo ${HOSTALIAS_ROOT_CERT} | \
 sed 's/\\n/\n/g' | \
@@ -52,6 +59,9 @@ ARG home=/srv/app
 ARG MSCA_NG_CERT_LOCATION=/usr/local/share/ca-certificates/env.crt
 ENV MSCA_NG_CERT_LOCATION=$MSCA_NG_CERT_LOCATION
 
+ARG ECAS_CERT_LOCATION=/usr/local/share/ca-certificates/ecas_env.crt
+ENV ECAS_CERT_LOCATION=$ECAS_CERT_LOCATION
+
 RUN addgroup \
     -S ${group} \
     --gid 1001 && \
@@ -67,6 +77,7 @@ WORKDIR ${home}
 
 COPY --from=build /etc/ssl/certs/root.crt /etc/ssl/certs/root.crt
 COPY --from=build --chown=${user}:${group} /usr/local/share/ca-certificates/env.crt ${MSCA_NG_CERT_LOCATION}
+COPY --from=build --chown=${user}:${group} /usr/local/share/ca-certificates/ecas_env.crt ${ECAS_CERT_LOCATION}
 
 RUN apk update && \
 apk add ca-certificates && \
@@ -131,6 +142,8 @@ ENV AUTH_DISABLED=$AUTH_DISABLED
 
 ARG AUTH_ECAS_GLOBAL_LOGOUT_URL
 ENV AUTH_ECAS_GLOBAL_LOGOUT_URL=$AUTH_ECAS_GLOBAL_LOGOUT_URL
+
+ENV NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/ecas_env.crt
 # ECAS/next-auth env end
 
 ARG PORT=3000

--- a/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
@@ -56,6 +56,8 @@ extraEnv:
     value: {{ env "AUTH_ECAS_REFRESH_ENDPOINT" }} 
   - name: MSCA_NG_USER_ENDPOINT
     value: {{ env "MSCA_NG_USER_ENDPOINT" }}
+  - name: AUTH_ECAS_CA
+    value: {{ env "AUTH_ECAS_CA" }}
   - name: AUTH_PRIVATE
     valueFrom:
       secretKeyRef:
@@ -180,6 +182,7 @@ secrets:
       HOSTALIAS_HOSTNAME: {{ env "HOSTALIAS_HOSTNAME" }}
       HOSTALIAS_CERT: {{ env "HOSTALIAS_CERT" }}
       MSCA_NG_CREDS: {{ env "MSCA_NG_CREDS" }}
+      AUTH_ECAS_CA: {{ env "AUTH_ECAS_CA" }}
 
   msca-d-frontend-auth-{{ requiredEnv "BRANCH" | lower }}:
     labels:


### PR DESCRIPTION
The new 10.* IP's (and their DNS) for ECAS RAOIDC come with a new certificate chain that has to be added so that the sade servers can successfully communicate with RAOIDC. These changes add that certificate to the Dockerfile. Note that it is necessary to add a build argument in teamcity for the cert to be included in the container successfully:` --build-arg AUTH_ECAS_CA=%env.AUTH_ECAS_CA%`

There is a corresponding vault entry to house the new certificate (%vault:bdm-dev-secure-client-hub/data/NEXT-AUTH!/AUTH_ECAS_CA%)