### PR TITLE
Fix alerts not appearing

### DIFF
--- a/__tests__/components/Card.test.js
+++ b/__tests__/components/Card.test.js
@@ -33,4 +33,6 @@ describe('Card', () => {
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })
+
+  // TODO: Add a test that if an alert is added it actually appears
 })

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -35,7 +35,6 @@ const Card = ({
       alert_icon_id: '',
     },
   ],
-  hasAlert,
   locale,
   cardTitle,
   viewMoreLessCaption,
@@ -111,27 +110,23 @@ const Card = ({
       />
       {!isOpen ? null : (
         <div>
-          {hasAlert &&
-            cardAlert.map((alert, index) => {
-              const alertType = alert.type[0].split('/').pop()
-              return (
-                <ul
-                  className="w-full pb-3 sm:px-8 sm:pb-6 md:px-15"
-                  key={index}
-                >
-                  <ContextualAlert
-                    id={alert.id}
-                    type={alertType}
-                    alertHeading={alert.alertHeading}
-                    alertBody={alert.alertBody}
-                    alert_icon_alt_text={`${alertType} ${
-                      locale === 'fr' ? 'Icônes' : 'icon'
-                    }`}
-                    alert_icon_id={` alert-icon ${alert.id}`}
-                  />
-                </ul>
-              )
-            })}
+          {cardAlert.map((alert, index) => {
+            const alertType = alert.type[0].split('/').pop()
+            return (
+              <ul className="w-full pb-3 sm:px-8 sm:pb-6 md:px-15" key={index}>
+                <ContextualAlert
+                  id={alert.id}
+                  type={alertType}
+                  alertHeading={alert.alertHeading}
+                  alertBody={alert.alertBody}
+                  alert_icon_alt_text={`${alertType} ${
+                    locale === 'fr' ? 'Icônes' : 'icon'
+                  }`}
+                  alert_icon_id={` alert-icon ${alert.id}`}
+                />
+              </ul>
+            )
+          })}
           <div className="pb-6" data-cy="sectionList">
             {children}
           </div>


### PR DESCRIPTION
## [ADO-281405](https://dev.azure.com/VP-BD/DECD/_workitems/edit/281405)

### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary

### Description of proposed changes:

Bugfix for card alerts not appearing. `hasAlert` wasn't being passed in and was always true by the default props (which accidentally didn't get transferred). This is highly misleading since it's dependent on the code itself to not render when there was no alerts, so `hasAlert` has been removed entirely.

### What to test for/How to test

Card alerts should now appear

### Additional Notes
