### PR TITLE
accommodate an additional hostalias in helm

### DIFF
--- a/helm/charts/secure-client-hub/templates/deployment.yaml
+++ b/helm/charts/secure-client-hub/templates/deployment.yaml
@@ -32,6 +32,13 @@ spec:
         {{- range .Values.hostAliases.hostnames }}
         - {{ . | quote }}
         {{- end }}
+        {{- if .Values.raoidcAlias.enabled }}
+      - ip: "{{ .Values.raoidcAlias.ip }}"
+        hostnames:
+        {{- range .Values.raoidcAlias.hostnames }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/charts/secure-client-hub/values.yaml
+++ b/helm/charts/secure-client-hub/values.yaml
@@ -74,3 +74,6 @@ oauth:
 
 hostAliases:
   enabled: false
+
+raoidcAlias:
+  enabled: false

--- a/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
+++ b/helmfile/overrides/secure-client-hub/dev/secure-client-hub.yaml.gotmpl
@@ -274,3 +274,10 @@ hostAliases:
   hostnames:
     - {{ env "HOSTALIAS_HOSTNAME" }}
 {{- end }}
+{{- if env "RAOIDC_HOSTALIAS_ENABLED" }}
+raoidcAlias:
+  enabled: {{ env "RAOIDC_HOSTALIAS_ENABLED" }}
+  ip: "{{ env "RAOIDC_HOSTALIAS_IP" }}"
+  hostnames:
+    - {{ env "RAOIDC_HOSTALIAS_HOSTNAME" }}
+{{- end }}


### PR DESCRIPTION
This introduces changes to the container to override the dns<->ip relationship to be able to reach ECAS endpoints (RAOIDC, RASCL) with their expected dns but using the new 10.* IP range provided by SSC.

- An additional ssl certificate associated to the 10.* ip's gets added to the container. Note that a new build argument is needed to pull in the new ssl certificate
- An additional ip/dns resolution gets added to /etc/hosts file within the container to override the real dns resolutions on the cluster and ssc network

