### PR TITLE
Change the CAL link to open in the same tab

### DIFF
--- a/components/MostReqTasks.tsx
+++ b/components/MostReqTasks.tsx
@@ -39,8 +39,6 @@ const MostReqTasks = ({
   acronym,
 }: MostReqTasksProps) => {
   const newTabTaskExceptions: string[] = [
-    'https://protege-secure.pca-cal.ca/en/Account/Authorize',
-    'https://protege-secure.pca-cal.ca/fr/Compte/Autoriser',
   ]
 
   return (

--- a/components/contact/ContactSectionRow.tsx
+++ b/components/contact/ContactSectionRow.tsx
@@ -41,8 +41,6 @@ export const ContactSectionRow = ({
     'https://eservices.canada.ca/fr/service/',
     'https://ep-be.alpha.service.canada.ca/en',
     'https://ep-be.alpha.service.canada.ca/fr',
-    'https://protege-secure.pca-cal.ca/en/Account/Authorize',
-    'https://protege-secure.pca-cal.ca/fr/Compte/Autoriser',
   ]
   return (
     <div className={`grid grid-cols-1 py-2 md:grid-cols-12 ${''}`}>


### PR DESCRIPTION
## [ADO-297222](https://dev.azure.com/VP-BD/DECD/_workitems/edit/297222)


### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary

### Description of proposed changes:
Open the Canada Apprentice Loan application in the same tab

### What to test for/How to test
When clicking on the Canada Apprentice Loan application link, the form opens in the same tab instead of a new one. 

### Additional Notes
