### PR TITLE
Push error events instead of pageloads on error pages

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -71,6 +71,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       accessRights: '1',
     },
   }
+
   return {
     props: {
       locale,
@@ -80,6 +81,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       isAuth: process.env.AUTH_DISABLED ?? true,
       aaPrefix: `ESDC-EDSC_MSCA-MSDC-SCH:404 Error`,
       aaMenuPrefix: `ESDC-EDSC_MSCA-MSDC-SCH:Nav Menu`,
+      errType: '404',
     },
   }
 }

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -80,6 +80,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       isAuth: process.env.AUTH_DISABLED ?? true,
       aaPrefix: `ESDC-EDSC_MSCA-MSDC-SCH:500 Error`,
       aaMenuPrefix: `ESDC-EDSC_MSCA-MSDC-SCH:Nav Menu`,
+      errType: '500',
     },
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -24,22 +24,19 @@ export default function MyApp({ Component, pageProps, router }) {
    *  @see https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics
    * */
   useEffect(() => {
-    const handleRouteChange = () => {
-      // only push event if pathname is different
-      if (window.location.pathname !== appPreviousLocationPathname) {
+    // only push event if pathname is different
+    if (window.location.pathname !== appPreviousLocationPathname) {
+      if (pageProps.errType !== undefined) {
+        window.adobeDataLayer?.push?.({
+          event: 'error',
+          error: pageProps.errType,
+        })
+      } else {
         window.adobeDataLayer?.push?.({ event: 'pageLoad' })
-        appPreviousLocationPathname = window.location.pathname
       }
+      appPreviousLocationPathname = window.location.pathname
     }
-
-    handleRouteChange()
-    router.events.on('routeChangeComplete', handleRouteChange)
-    router.events.on('hashChangeComplete', handleRouteChange)
-    return () => {
-      router.events.off('routeChangeComplete', handleRouteChange)
-      router.events.off('hashChangeComplete', handleRouteChange)
-    }
-  }, [router.events])
+  }, [router.asPath, pageProps.errType])
 
   /* istanbul ignore next */
   return (


### PR DESCRIPTION
## [ADO-297006](https://dev.azure.com/VP-BD/DECD/_workitems/edit/297006)

### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary

### Description of proposed changes:

Simplified AA push and made it push errors on error pages instead of pageloads.

### What to test for/How to test

That the app pushes error events on error pages and pageloads on other pages.

### Additional Notes
