### PR TITLE
Fix beforeInteractive lint warning

### DIFF
--- a/components/MetaData.tsx
+++ b/components/MetaData.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head'
-import Script from 'next/script'
 
 interface Content {
   title: string
@@ -60,21 +59,6 @@ const MetaData = ({ language, data }: MetaDataProps) => {
         <meta name="dcterms.accessRights" content={d.accessRights} />
         <meta name="dcterms.service" content={d.service} />
       </Head>
-
-      {
-        // AA script must be loaded before the pageLoad event fires
-        process.env.ENVIRONMENT === 'production' ? (
-          <Script
-            strategy="beforeInteractive"
-            src="//assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-59d77766b86a.min.js"
-          />
-        ) : (
-          <Script
-            strategy="beforeInteractive"
-            src="https://assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-cad75bf2f0d2-staging.min.js"
-          />
-        )
-      }
     </>
   )
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,4 +1,5 @@
 import { Html, Head, Main, NextScript } from 'next/document'
+import Script from 'next/script'
 
 export default function Document() {
   return (
@@ -9,6 +10,20 @@ export default function Document() {
         <script>0</script>
         <Main />
         <NextScript />
+        {
+          // AA script must be loaded before the pageLoad event fires
+          process.env.ENVIRONMENT === 'production' ? (
+            <Script
+              strategy="beforeInteractive"
+              src="//assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-59d77766b86a.min.js"
+            />
+          ) : (
+            <Script
+              strategy="beforeInteractive"
+              src="https://assets.adobedtm.com/be5dfd287373/9b9cb7867b5b/launch-cad75bf2f0d2-staging.min.js"
+            />
+          )
+        }
       </body>
     </Html>
   )


### PR DESCRIPTION
## [ADO-297006](https://dev.azure.com/VP-BD/DECD/_workitems/edit/297006)

### Changelog - "fix:" for bug fixes, "feat:" for features. Read more about Conventional Commits at https://www.conventionalcommits.org/en/v1.0.0/#summary

### Description of proposed changes:

`beforeInteractive` has been moved to `_document.js`

### What to test for/How to test

Lint warning no longer appears after `npm run lint`

### Additional Notes

https://nextjs.org/docs/messages/no-before-interactive-script-outside-document