### PR TITLE
update zap test version

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -33,7 +33,7 @@ jobs:
           AEM_GRAPHQL_FOLDER: ${{secrets.AEM_GRAPHQL_FOLDER}}
 
       - name: OWASP ZAP FULL Scan
-        uses: zaproxy/action-full-scan@v0.9.0
+        uses: zaproxy/action-full-scan@v0.12.0
         with:
           target: "http://localhost:3000"
           fail_action: "false"


### PR DESCRIPTION
versions prior to 0.12 were using the deprecated upload artifact

See: https://github.com/zaproxy/action-full-scan/releases/tag/v0.12.0
